### PR TITLE
Bump ring to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ failure_derive = "0.1"
 log = "0.4"
 oauth2 = { git = "https://github.com/ramosbugs/oauth2-rs.git", branch = "master" }
 rand = "0.4"
-ring = "0.12"
+ring = "0.13"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-untrusted = "0.5"
+untrusted = "0.6"
 url = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Also bump untrusted to 0.6, as ring depends on it.

~_ring_ versions less than 0.12 do not support multiple version of _ring_ in a crate's dependency graph due to how its native crate works. _ring_ 0.13 fixes this, and bumping to this version will allow this crate to interoperate with other crates with _ring_ in their dependency graph more easily.~

Ah, looks like I misread and support for multiple versions hasn't landed in _ring_ yet, so this PR isn't especially useful on its own.