### PR TITLE
Avoid possible duplicate version-conflicting dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ failure = "0.1"
 failure_derive = "0.1"
 futures-0-1 = { version = "0.1", optional = true, package = "futures" }
 futures-0-3 = { version = "0.3", optional = true, package = "futures" }
-http = "0.1"
 itertools = "0.7.8"
 log = "0.4"
 oauth2 = { version = "=3.0.0-alpha.9", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ futures-0-3 = { version = "0.3", optional = true, package = "futures" }
 http = "0.1"
 itertools = "0.7.8"
 log = "0.4"
-oauth2 = "=3.0.0-alpha.9"
+oauth2 = { version = "=3.0.0-alpha.9", default-features = false }
 rand = "0.6"
 ring = "0.14"
 serde = "1.0"

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -6,9 +6,9 @@ use failure::Fail;
 use futures_0_1::{Future, IntoFuture};
 #[cfg(feature = "futures-03")]
 use futures_0_3;
-use http::header::{HeaderValue, ACCEPT};
-use http::method::Method;
-use http::status::StatusCode;
+use oauth2::http::header::{HeaderValue, ACCEPT};
+use oauth2::http::method::Method;
+use oauth2::http::status::StatusCode;
 use oauth2::{AuthUrl, Scope, TokenUrl};
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/src/http_utils.rs
+++ b/src/http_utils.rs
@@ -1,4 +1,4 @@
-use http::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use oauth2::http::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use oauth2::AccessToken;
 
 pub const MIME_TYPE_JSON: &str = "application/json";

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -8,9 +8,9 @@ use failure::Fail;
 use futures_0_1::{Future, IntoFuture};
 #[cfg(feature = "futures-03")]
 use futures_0_3;
-use http::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE};
-use http::method::Method;
-use http::status::StatusCode;
+use oauth2::http::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE};
+use oauth2::http::method::Method;
+use oauth2::http::status::StatusCode;
 use serde;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer, MapAccess, Visitor};
 use serde::ser::SerializeMap;

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,11 +11,11 @@ use failure::Fail;
 use futures_0_1::Future;
 #[cfg(feature = "futures-03")]
 use futures_0_3;
-use http::header::{HeaderValue, ACCEPT};
-use http::method::Method;
-use http::status::StatusCode;
 use oauth2;
 use oauth2::helpers::deserialize_space_delimited_vec;
+use oauth2::http::header::{HeaderValue, ACCEPT};
+use oauth2::http::method::Method;
+use oauth2::http::status::StatusCode;
 use rand::{thread_rng, Rng};
 use ring::constant_time;
 use serde::de::DeserializeOwned;

--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -7,9 +7,9 @@ use failure::Fail;
 use futures_0_1::{Future, IntoFuture};
 #[cfg(feature = "futures-03")]
 use futures_0_3;
-use http::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
-use http::method::Method;
-use http::status::StatusCode;
+use oauth2::http::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
+use oauth2::http::method::Method;
+use oauth2::http::status::StatusCode;
 use oauth2::AccessToken;
 use serde_json;
 use url::Url;

--- a/tests/rp_certification_code.rs
+++ b/tests/rp_certification_code.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::expect_fun_call)]
 extern crate env_logger;
 extern crate failure;
-extern crate http;
 #[macro_use]
 extern crate log;
 extern crate openidconnect;
@@ -12,8 +11,8 @@ extern crate url;
 
 use std::collections::HashMap;
 
-use http::header::LOCATION;
-use http::method::Method;
+use reqwest::header::LOCATION;
+use reqwest::Method;
 use reqwest::{Client, RedirectPolicy};
 use url::Url;
 


### PR DESCRIPTION
Disable default features in the oath2 dependency.  This gets rid of the reqwest 0.9 dependency when using reqwest 0.10, getting rid of loads of transitive dependencies and some confusion.

Also remove direct http dependency, to avoid version confusion.  Use the http exported from oauth2 (or from reqwest, in a test) rather than having a direct http dependency.