### PR TITLE
Respect potential postfixes to conten types in user_info

### DIFF
--- a/src/http_utils.rs
+++ b/src/http_utils.rs
@@ -6,6 +6,14 @@ pub const MIME_TYPE_JWT: &str = "application/jwt";
 
 pub const BEARER: &str = "Bearer";
 
+pub fn header_starts_with_ignoring_case(header: &HeaderValue, expected_start: &str) -> bool {
+    header
+        .to_str()
+        .ok()
+        .filter(|ct| ct.to_lowercase().starts_with(&expected_start.to_lowercase()))
+        .is_some()
+}
+
 pub fn check_content_type(headers: &HeaderMap, expected_content_type: &str) -> Result<(), String> {
     headers
         .get(CONTENT_TYPE)
@@ -13,16 +21,12 @@ pub fn check_content_type(headers: &HeaderMap, expected_content_type: &str) -> R
             // Section 3.1.1.1 of RFC 7231 indicates that media types are case insensitive and
             // may be followed by optional whitespace and/or a parameter (e.g., charset).
             // See https://tools.ietf.org/html/rfc7231#section-3.1.1.1.
-            if content_type
-                .to_str()
-                .ok()
-                .filter(|ct| ct.to_lowercase().starts_with(&expected_content_type.to_lowercase()))
-                .is_none() {
+            if !header_starts_with_ignoring_case(&content_type, expected_content_type) {
                 Err(
                     format!(
                         "Unexpected response Content-Type: {:?}, should be `{}`",
                         content_type,
-                        MIME_TYPE_JSON
+                        expected_content_type
                     )
                 )
             } else {

--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -15,7 +15,7 @@ use serde_json;
 use url::Url;
 
 use crate::helpers::FilteredFlatten;
-use crate::http_utils::{auth_bearer, MIME_TYPE_JSON, MIME_TYPE_JWT};
+use crate::http_utils::{auth_bearer, header_starts_with_ignoring_case, MIME_TYPE_JSON, MIME_TYPE_JWT};
 use crate::jwt::{JsonWebTokenError, JsonWebTokenJsonPayloadSerde};
 use crate::types::helpers::deserialize_string_or_vec_opt;
 use crate::types::LocalizedClaim;
@@ -156,7 +156,7 @@ where
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| HeaderValue::from_static(MIME_TYPE_JSON))
         {
-            ref content_type if content_type == HeaderValue::from_static(MIME_TYPE_JSON) => {
+            ref content_type if header_starts_with_ignoring_case(&content_type, MIME_TYPE_JSON) => {
                 if self.require_signed_response {
                     return Err(UserInfoError::ClaimsVerification(
                         ClaimsVerificationError::NoSignature,
@@ -167,7 +167,7 @@ where
                     self.signed_response_verifier.expected_subject(),
                 )
             }
-            ref content_type if content_type == HeaderValue::from_static(MIME_TYPE_JWT) => {
+            ref content_type if header_starts_with_ignoring_case(&content_type, MIME_TYPE_JWT) => {
                 let jwt_str = String::from_utf8(http_response.body).map_err(|_| {
                     UserInfoError::Other("response body has invalid UTF-8 encoding".to_string())
                 })?;


### PR DESCRIPTION
## Problem
Getting a user_info fails on OIDC providers such as Gitlab that have an extended content type (e.g. with `charset`) fails with the exiting code because the content type is tested for equality.

## Implemented fix
I've simply moved existing code testing a header value for a given prefix into a function and used it in two relevant cases that were relying on equality before.