### PR TITLE
Adding exchange_password to Client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,7 +618,7 @@ pub use oauth2::{
     HttpRequest, HttpResponse, PkceCodeChallenge, PkceCodeChallengeMethod, PkceCodeVerifier,
     RedirectUrl, RefreshToken, RefreshTokenRequest, RequestTokenError, Scope,
     StandardErrorResponse, StandardTokenResponse, TokenResponse as OAuth2TokenResponse, TokenType,
-    TokenUrl,
+    TokenUrl, ResourceOwnerUsername, ResourceOwnerPassword, PasswordTokenRequest
 };
 
 ///
@@ -990,6 +990,22 @@ where
         'a: 'b,
     {
         self.oauth2_client.exchange_refresh_token(refresh_token)
+    }
+
+    ///
+    /// Creates a request builder for exchanging credentials for an access token.
+    ///
+    /// See https://tools.ietf.org/html/rfc6749#section-6
+    ///
+    pub fn exchange_password<'a, 'b>(
+        &'a self,
+        username: &'b ResourceOwnerUsername,
+        password: &'b ResourceOwnerPassword,
+    ) -> PasswordTokenRequest<'b, TE, TR, TT>
+    where
+        'a: 'b,
+    {
+        self.oauth2_client.exchange_password(username, password)
     }
 
     ///


### PR DESCRIPTION
This PR adds the `exchange_password` functionality from oauth2.

While this does not allow fetching an [id_token](https://docs.rs/openidconnect/1.0.0-alpha.13/openidconnect/trait.TokenResponse.html) (at least not using keycloak), it is possible to use the access_token with the [user_info](https://docs.rs/openidconnect/1.0.0-alpha.13/openidconnect/struct.Client.html#method.user_info) function.

Is there a reason why this function is not included at the moment?