### PR TITLE
Updating itertools to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ failure_derive = "0.1"
 futures-0-1 = { version = "0.1", optional = true, package = "futures" }
 futures-0-3 = { version = "0.3", optional = true, package = "futures" }
 http = "0.1"
-itertools = "0.7.8"
+itertools = "0.9"
 log = "0.4"
 oauth2 = "=3.0.0-alpha.9"
 rand = "0.7"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -599,8 +599,8 @@ macro_rules! serialize_fields {
         if let Some(ref field_map) = $self.$field {
             use itertools::sorted;
             let sorted_field_map = sorted(field_map.iter());
-            for (language_tag_opt, $field) in sorted_field_map.iter() {
-                if let Some(ref language_tag) = *language_tag_opt {
+            for (language_tag_opt, $field) in sorted_field_map {
+                if let Some(ref language_tag) = language_tag_opt {
                     $map.serialize_entry(
                         &format!(concat!(stringify!($field), "#{}"), language_tag.as_ref()),
                         &$field

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -1030,7 +1030,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(client_metadata.client_name().unwrap().clone()),
+            sorted(client_metadata.client_name().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, ClientName)>>(),
             vec![
                 (None, ClientName::new("Example".to_string())),
                 (
@@ -1040,7 +1041,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(client_metadata.logo_uri().unwrap().clone()),
+            sorted(client_metadata.logo_uri().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, LogoUrl)>>(),
             vec![
                 (
                     None,
@@ -1053,7 +1055,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(client_metadata.client_uri().unwrap().clone()),
+            sorted(client_metadata.client_uri().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, ClientUrl)>>(),
             vec![
                 (
                     None,
@@ -1066,7 +1069,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(client_metadata.policy_uri().unwrap().clone()),
+            sorted(client_metadata.policy_uri().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, PolicyUrl)>>(),
             vec![
                 (
                     None,
@@ -1079,7 +1083,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(client_metadata.tos_uri().unwrap().clone()),
+            sorted(client_metadata.tos_uri().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, ToSUrl)>>(),
             vec![
                 (
                     None,
@@ -1352,7 +1357,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(registration_response.client_name().unwrap().clone()),
+            sorted(registration_response.client_name().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, ClientName)>>(),
             vec![
                 (None, ClientName::new("Example".to_string())),
                 (
@@ -1362,7 +1368,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(registration_response.logo_uri().unwrap().clone()),
+            sorted(registration_response.logo_uri().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, LogoUrl)>>(),
             vec![
                 (
                     None,
@@ -1375,7 +1382,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(registration_response.client_uri().unwrap().clone()),
+            sorted(registration_response.client_uri().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, ClientUrl)>>(),
             vec![
                 (
                     None,
@@ -1388,7 +1396,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(registration_response.policy_uri().unwrap().clone()),
+            sorted(registration_response.policy_uri().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, PolicyUrl)>>(),
             vec![
                 (
                     None,
@@ -1401,7 +1410,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            sorted(registration_response.tos_uri().unwrap().clone()),
+            sorted(registration_response.tos_uri().unwrap().clone())
+                .collect::<Vec<(Option<LanguageTag>, ToSUrl)>>(),
             vec![
                 (
                     None,


### PR DESCRIPTION
Itertools:
https://github.com/rust-itertools/itertools/compare/0.7.11...v0.9.0
A lot of changes, deprecations and switch to 2018. Nothing that should affect this crate thou

`itertools::sorted` now returns an `IntoIter` instead of a `Vec`. Thus `iter` must not be called and we have to `collect` inside of the tests