### PR TITLE
Updating base64 to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ reqwest-010 = ["oauth2/reqwest-010"]
 nightly = []
 
 [dependencies]
-base64 = "0.9"
+base64 = "0.12"
 chrono = "0.4"
 failure = "0.1"
 failure_derive = "0.1"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1293,5 +1293,9 @@ impl AsRef<str> for CoreSubjectIdentifierType {
 }
 impl SubjectIdentifierType for CoreSubjectIdentifierType {}
 
+pub(crate) fn base64_url_safe_no_pad() -> base64::Config {
+    base64::URL_SAFE_NO_PAD.decode_allow_trailing_bits(true)
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -387,25 +387,30 @@ where
                         )));
                     }
 
-                    let header_json = base64::decode_config(parts[0], base64::URL_SAFE_NO_PAD)
-                        .map_err(|err| {
-                            DE::custom(format!("Invalid base64url header encoding: {:?}", err))
-                        })?;
+                    let header_json =
+                        base64::decode_config(parts[0], crate::core::base64_url_safe_no_pad())
+                            .map_err(|err| {
+                                DE::custom(format!("Invalid base64url header encoding: {:?}", err))
+                            })?;
                     header = serde_json::from_slice(&header_json).map_err(|err| {
                         DE::custom(format!("Failed to parse header JSON: {:?}", err))
                     })?;
 
-                    let raw_payload = base64::decode_config(parts[1], base64::URL_SAFE_NO_PAD)
-                        .map_err(|err| {
-                            DE::custom(format!("Invalid base64url payload encoding: {:?}", err))
-                        })?;
+                    let raw_payload =
+                        base64::decode_config(parts[1], crate::core::base64_url_safe_no_pad())
+                            .map_err(|err| {
+                                DE::custom(format!("Invalid base64url payload encoding: {:?}", err))
+                            })?;
                     payload = S::deserialize::<DE>(&raw_payload)?;
 
-                    signature = base64::decode_config(parts[2], base64::URL_SAFE_NO_PAD).map_err(
-                        |err| {
-                            DE::custom(format!("Invalid base64url signature encoding: {:?}", err))
-                        },
-                    )?;
+                    signature =
+                        base64::decode_config(parts[2], crate::core::base64_url_safe_no_pad())
+                            .map_err(|err| {
+                                DE::custom(format!(
+                                    "Invalid base64url signature encoding: {:?}",
+                                    err
+                                ))
+                            })?;
 
                     signing_input = format!("{}.{}", parts[0], parts[1]);
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1254,12 +1254,14 @@ mod serde_base64url_byte_array {
         let value: Value = Deserialize::deserialize(deserializer)?;
         let base64_encoded: String = from_value(value).map_err(D::Error::custom)?;
 
-        base64::decode_config(&base64_encoded, base64::URL_SAFE_NO_PAD).map_err(|err| {
-            D::Error::custom(format!(
-                "invalid base64url encoding `{}`: {:?}",
-                base64_encoded, err
-            ))
-        })
+        base64::decode_config(&base64_encoded, crate::core::base64_url_safe_no_pad()).map_err(
+            |err| {
+                D::Error::custom(format!(
+                    "invalid base64url encoding `{}`: {:?}",
+                    base64_encoded, err
+                ))
+            },
+        )
     }
 
     pub fn serialize<S>(v: &[u8], serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
I had to split them. I underestimated the changes made to base64.

base64 removed the whitespace stripping. However the
auther provides a code snippet on the RELEASE Page
which fixes that [1]
`filter(|b| !b" \n\t\r\x0b\x0c".contains(b)`.

Unfortunatly that introduces an additional allocation
which, however, also exited before but was inside
base64.

The change to the test is necessary as the error
detection was improved. Now it is necessary that the
invalid signature is made out of valid base64