### PR TITLE
Migrating to new oauth4 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,9 @@ before_script:
   - cargo install --force cargo-audit
   - cargo install --force cargo-when
 script:
-  - cargo test
-  - cargo test --examples
+  - cargo test --tests --examples
+  - cargo test --doc
   - cargo test --all-features
-  - cargo build --features futures-01 --no-default-features
-  - cargo build --features futures-03 --no-default-features
   - cargo audit
 after_success: |
   RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,8 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["reqwest-09"]
+default = ["reqwest-010"]
 curl = ["oauth2/curl"]
-futures-01 = ["oauth2/futures-01", "futures-0-1"]
-futures-03 = ["oauth2/futures-03", "futures-0-3"]
-reqwest-09 = ["oauth2/reqwest-09"]
 reqwest-010 = ["oauth2/reqwest-010"]
 nightly = []
 
@@ -28,12 +25,10 @@ base64 = "0.12"
 chrono = "0.4"
 failure = "0.1"
 failure_derive = "0.1"
-futures-0-1 = { version = "0.1", optional = true, package = "futures" }
-futures-0-3 = { version = "0.3", optional = true, package = "futures" }
-http = "0.1"
+http = "0.2"
 itertools = "0.9"
 log = "0.4"
-oauth2 = "3.0"
+oauth2 = { version = "4.0.0-alpha.1", default-features = false }
 rand = "0.7"
 ring = "0.16"
 serde = "1.0"
@@ -44,8 +39,8 @@ untrusted = "0.7"
 url = "2.1"
 
 [dev-dependencies]
-color-backtrace = { version = "0.2" }
-env_logger = "0.5"
-pretty_assertions = "0.5"
-reqwest_ = { package = "reqwest", version = "0.9" }
-retry = "0.5"
+color-backtrace = { version = "0.4" }
+env_logger = "0.7"
+pretty_assertions = "0.6"
+reqwest_ = { package = "reqwest", features = ["blocking"], version = "0.10" }
+retry = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,51 +23,20 @@
 //!
 //! # Importing `openidconnect`: selecting an HTTP client interface
 //!
-//! This library offers a flexible HTTP client interface with three modes:
+//! This library offers a flexible HTTP client interface with two modes:
 //!  * **Synchronous (blocking)**
-//!
-//!    The synchronous interface is available for any combination of feature flags.
-//!
-//!    Example import in `Cargo.toml`:
-//!    ```toml
-//!    openidconnect = "1.0"
-//!    ```
-//!  * **Asynchronous via `futures` 0.1**
-//!
-//!    Support is enabled via the `futures-01` feature flag.
-//!
-//!    Example import in `Cargo.toml`:
-//!    ```toml
-//!    openidconnect = { version = "1.0", features = ["futures-01"] }
-//!    ```
-//!  * **Async/await via `futures` 0.3**
-//!
-//!    Support is enabled via the `futures-03` feature flag. Typically, the default
-//!    support for `reqwest` 0.9 is also disabled when using async/await. If desired, the
-//!    `reqwest-010` feature flag can be used to enable `reqwest` 0.10 and its async/await
-//!    client interface.
-//!
-//!    Example import in `Cargo.toml`:
-//!    ```toml
-//!    openidconnect = { version = "1.0", features = ["futures-03"], default-features = false }
-//!    ```
+//!  * **Async/await**
 //!
 //! For the HTTP client modes described above, the following HTTP client implementations can be
 //! used:
 //!  * **[`reqwest`]**
 //!
-//!    The `reqwest` HTTP client supports all three modes. By default, `reqwest` 0.9 is enabled,
+//!    The `reqwest` HTTP client supports both modes. By default, `reqwest` 0.10 is enabled,
 //!    which supports the synchronous and asynchronous `futures` 0.1 APIs.
 //!
 //!    Synchronous client: [`reqwest::http_client`]
 //!
-//!    Asynchronous `futures` 0.1 client: [`reqwest::future_http_client`]
-//!
-//!    Async/await `futures` 0.3 client: [`reqwest::async_http_client`]. This mode requires
-//!    `reqwest` 0.10, which can be enabled via the `reqwest-010` feature flag. Typically, the
-//!    default features are also disabled (`default-features = false` in `Cargo.toml`) to remove the
-//!    dependency on `reqwest` 0.9 when using `reqwest` 0.10. However, both can be used together if
-//!    both asynchronous interfaces are desired.
+//!    Async/await `futures` 0.3 client: [`reqwest::async_http_client`]
 //!
 //!  * **[`curl`]**
 //!
@@ -80,7 +49,7 @@
 //!
 //!    In addition to the clients above, users may define their own HTTP clients, which must accept
 //!    an [`HttpRequest`] and return an [`HttpResponse`] or error. Users writing their own clients
-//!    may wish to disable the default `reqwest` 0.9 dependency by specifying
+//!    may wish to disable the default `reqwest` 0.10 dependency by specifying
 //!    `default-features = false` in `Cargo.toml`:
 //!    ```toml
 //!    openidconnect = { version = "1.0", default-features = false }
@@ -90,21 +59,12 @@
 //!    ```ignore
 //!    FnOnce(HttpRequest) -> Result<HttpResponse, RE>
 //!    where RE: failure::Fail
-//!    ```
-//!
-//!    Asynchronous `futures` 0.1 HTTP clients should implement the following trait:
-//!    ```ignore
-//!    FnOnce(HttpRequest) -> F
-//!    where
-//!      F: Future<Item = HttpResponse, Error = RE>,
-//!      RE: failure::Fail
-//!    ```
 //!
 //!    Async/await `futures` 0.3 HTTP clients should implement the following trait:
 //!    ```ignore
-//!    FnOnce(HttpRequest) -> F + Send
+//!    FnOnce(HttpRequest) -> F
 //!    where
-//!      F: Future<Output = Result<HttpResponse, RE>> + Send,
+//!      F: Future<Output = Result<HttpResponse, RE>>,
 //!      RE: failure::Fail
 //!    ```
 //!
@@ -145,11 +105,11 @@
 //!   CoreProviderMetadata,
 //!   CoreResponseType,
 //! };
-//! # #[cfg(any(feature = "reqwest-09", feature = "reqwest-010"))]
+//! # #[cfg(feature = "reqwest-010")]
 //! use openidconnect::reqwest::http_client;
 //! use url::Url;
 //!
-//! # #[cfg(any(feature = "reqwest-09", feature = "reqwest-010"))]
+//! # #[cfg(feature = "reqwest-010")]
 //! # fn err_wrapper() -> Result<(), failure::Error> {
 //! // Use OpenID Connect Discovery to fetch the provider metadata.
 //! use openidconnect::{OAuth2TokenResponse, TokenResponse};
@@ -472,18 +432,13 @@
 //! # Async/Await API
 //!
 //! An asynchronous API for async/await is also provided.
-//! In order to use `futures` 0.3, include the `openidconnect` crate like this:
-//! ```toml
-//! openidconnect = { version = "1.0", features = ["futures-03"], default-features = false }
-//! ```
 //!
 //! ## Example
 //!
 //! ```rust,no_run
-//! # #[cfg(all(feature = "futures-03", feature = "reqwest-010"))]
+//! # #[cfg(feature = "reqwest-010")]
 //! use openidconnect::{
 //!     AccessTokenHash,
-//!     AsyncCodeTokenRequest,
 //!     AuthenticationFlow,
 //!     AuthorizationCode,
 //!     ClientId,
@@ -501,12 +456,12 @@
 //!   CoreProviderMetadata,
 //!   CoreResponseType,
 //! };
-//! # #[cfg(all(feature = "futures-03", feature = "reqwest-010"))]
+//! # #[cfg(feature = "reqwest-010")]
 //! use openidconnect::reqwest::async_http_client;
 //! use url::Url;
 //!
 //!
-//! # #[cfg(all(feature = "futures-03", feature = "reqwest-010"))]
+//! # #[cfg(feature = "reqwest-010")]
 //! # async fn err_wrapper() -> Result<(), failure::Error> {
 //! // Use OpenID Connect Discovery to fetch the provider metadata.
 //! use openidconnect::{OAuth2TokenResponse, TokenResponse};
@@ -615,10 +570,10 @@ use std::time::Duration;
 pub use oauth2::{
     AccessToken, AuthType, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CodeTokenRequest,
     CsrfToken, EmptyExtraTokenFields, ErrorResponse, ErrorResponseType, ExtraTokenFields,
-    HttpRequest, HttpResponse, PkceCodeChallenge, PkceCodeChallengeMethod, PkceCodeVerifier,
-    RedirectUrl, RefreshToken, RefreshTokenRequest, RequestTokenError, Scope,
-    StandardErrorResponse, StandardTokenResponse, TokenResponse as OAuth2TokenResponse, TokenType,
-    TokenUrl, ResourceOwnerUsername, ResourceOwnerPassword, PasswordTokenRequest
+    HttpRequest, HttpResponse, PasswordTokenRequest, PkceCodeChallenge, PkceCodeChallengeMethod,
+    PkceCodeVerifier, RedirectUrl, RefreshToken, RefreshTokenRequest, RequestTokenError,
+    ResourceOwnerPassword, ResourceOwnerUsername, Scope, StandardErrorResponse,
+    StandardTokenResponse, TokenResponse as OAuth2TokenResponse, TokenType, TokenUrl,
 };
 
 ///
@@ -630,14 +585,8 @@ pub use oauth2::url;
 #[cfg(feature = "curl")]
 pub use oauth2::curl;
 
-#[cfg(any(feature = "reqwest-09", feature = "reqwest-010"))]
+#[cfg(feature = "reqwest-010")]
 pub use oauth2::reqwest;
-
-#[cfg(feature = "futures-03")]
-pub use oauth2::{
-    AsyncClientCredentialsTokenRequest, AsyncCodeTokenRequest, AsyncPasswordTokenRequest,
-    AsyncRefreshTokenRequest,
-};
 
 pub use claims::{
     AdditionalClaims, AddressClaim, EmptyAdditionalClaims, GenderClaim, StandardClaims,
@@ -779,7 +728,7 @@ where
     JU: JsonWebKeyUse,
     K: JsonWebKey<JS, JT, JU>,
     P: AuthPrompt,
-    TE: ErrorResponse,
+    TE: 'static + ErrorResponse,
     TR: TokenResponse<AC, GC, JE, JS, JT, TT>,
     TT: TokenType + 'static,
 {
@@ -1479,7 +1428,7 @@ mod tests {
         }
 
         let (authorize_url, _, _) = client
-            .authorize_url(flow.clone(), new_csrf, new_nonce)
+            .authorize_url(flow, new_csrf, new_nonce)
             .add_scope(Scope::new("email".to_string()))
             .set_display(CoreAuthDisplay::Touch)
             .add_prompt(CoreAuthPrompt::Login)
@@ -1491,7 +1440,9 @@ mod tests {
             .add_auth_context_value(AuthenticationContextClass::new(
                 "urn:mace:incommon:iap:silver".to_string(),
             ))
-            .set_redirect_url(Cow::Owned(RedirectUrl::new("http://localhost:8888/alternative".to_string()).unwrap()))
+            .set_redirect_url(Cow::Owned(
+                RedirectUrl::new("http://localhost:8888/alternative".to_string()).unwrap(),
+            ))
             .url();
         assert_eq!(
             "https://example/authorize?response_type=code&client_id=aaa&\

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Error as FormatterError, Formatter};
+use std::future::Future;
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
@@ -7,10 +8,6 @@ use std::ops::Deref;
 
 use base64;
 use failure::Fail;
-#[cfg(feature = "futures-01")]
-use futures_0_1::Future;
-#[cfg(feature = "futures-03")]
-use futures_0_3;
 use http::header::{HeaderValue, ACCEPT};
 use http::method::Method;
 use http::status::StatusCode;
@@ -766,32 +763,12 @@ where
     /// Fetch a remote JSON Web Key Set from the specified `url` using the given async `http_client`
     /// (e.g., [`crate::reqwest::async_http_client`]).
     ///
-    #[cfg(feature = "futures-01")]
-    pub fn fetch_future<F, HC, RE>(
-        url: &JsonWebKeySetUrl,
-        http_client: HC,
-    ) -> impl Future<Item = Self, Error = DiscoveryError<RE>>
-    where
-        F: Future<Item = HttpResponse, Error = RE>,
-        HC: FnOnce(HttpRequest) -> F,
-        RE: Fail,
-    {
-        http_client(Self::fetch_request(url))
-            .map_err(DiscoveryError::Request)
-            .and_then(Self::fetch_response)
-    }
-
-    ///
-    /// Fetch a remote JSON Web Key Set from the specified `url` using the given async `http_client`
-    /// (e.g., [`crate::reqwest::async_http_client`]).
-    ///
-    #[cfg(feature = "futures-03")]
     pub async fn fetch_async<F, HC, RE>(
         url: &JsonWebKeySetUrl,
         http_client: HC,
     ) -> Result<Self, DiscoveryError<RE>>
     where
-        F: futures_0_3::Future<Output = Result<HttpResponse, RE>>,
+        F: Future<Output = Result<HttpResponse, RE>>,
         HC: FnOnce(HttpRequest) -> F,
         RE: Fail,
     {

--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -1,12 +1,9 @@
+use std::future::Future;
 use std::ops::Deref;
 use std::str;
 
 use chrono::{DateTime, Utc};
 use failure::Fail;
-#[cfg(feature = "futures-01")]
-use futures_0_1::{Future, IntoFuture};
-#[cfg(feature = "futures-03")]
-use futures_0_3;
 use http::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
 use http::method::Method;
 use http::status::StatusCode;
@@ -77,28 +74,6 @@ where
     /// Submits this request to the associated user info endpoint using the specified asynchronous
     /// HTTP client.
     ///
-    #[cfg(feature = "futures-01")]
-    pub fn request_future<AC, C, F, GC, RE>(
-        self,
-        http_client: C,
-    ) -> impl Future<Item = UserInfoClaims<AC, GC>, Error = UserInfoError<RE>>
-    where
-        AC: AdditionalClaims,
-        C: FnOnce(HttpRequest) -> F,
-        F: Future<Item = HttpResponse, Error = RE>,
-        GC: GenderClaim,
-        RE: Fail,
-    {
-        http_client(self.prepare_request())
-            .map_err(UserInfoError::Request)
-            .and_then(|http_response| self.user_info_response(http_response).into_future())
-    }
-
-    ///
-    /// Submits this request to the associated user info endpoint using the specified asynchronous
-    /// HTTP client.
-    ///
-    #[cfg(feature = "futures-03")]
     pub async fn request_async<AC, C, F, GC, RE>(
         self,
         http_client: C,
@@ -106,7 +81,7 @@ where
     where
         AC: AdditionalClaims,
         C: FnOnce(HttpRequest) -> F,
-        F: futures_0_3::Future<Output = Result<HttpResponse, RE>>,
+        F: Future<Output = Result<HttpResponse, RE>>,
         GC: GenderClaim,
         RE: Fail,
     {

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -130,7 +130,7 @@ where
     iss_required: bool,
     issuer: IssuerUrl,
     is_signature_check_enabled: bool,
-    other_aud_verifier_fn: Arc<dyn Fn(&Audience) -> bool + 'a + Send + Sync>,
+    other_aud_verifier_fn: Arc<dyn Fn(&Audience) -> bool + 'a>,
     signature_keys: JsonWebKeySet<JS, JT, JU, K>,
 }
 impl<'a, JS, JT, JU, K> JwtClaimsVerifier<'a, JS, JT, JU, K>
@@ -195,7 +195,7 @@ where
 
     pub fn set_other_audience_verifier_fn<T>(mut self, other_aud_verifier_fn: T) -> Self
     where
-        T: Fn(&Audience) -> bool + 'a + Send + Sync,
+        T: Fn(&Audience) -> bool + 'a,
     {
         self.other_aud_verifier_fn = Arc::new(other_aud_verifier_fn);
         self
@@ -695,7 +695,7 @@ where
     ///
     pub fn set_other_audience_verifier_fn<T>(mut self, other_aud_verifier_fn: T) -> Self
     where
-        T: Fn(&Audience) -> bool + 'a + Send + Sync,
+        T: Fn(&Audience) -> bool + 'a,
     {
         self.jwt_verifier = self
             .jwt_verifier

--- a/tests/rp_certification_code.rs
+++ b/tests/rp_certification_code.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 
 use http::header::LOCATION;
 use http::method::Method;
-use reqwest::{Client, RedirectPolicy};
+use reqwest::{blocking::Client, redirect::Policy};
 use url::Url;
 
 use openidconnect::core::{
@@ -98,7 +98,7 @@ impl TestState {
             log_debug!("Authorize URL: {:?}", url);
 
             let http_client = Client::builder()
-                .redirect(RedirectPolicy::none())
+                .redirect(Policy::none())
                 .build()
                 .unwrap();
             let redirect_response = http_client


### PR DESCRIPTION
(Build failure expected)

This time separating is a bit difficult so its all combined into one. 

* Removed future-01
* Removed reqwest-09
* Updated http to 0.2
* Updated dev dependencies to latest version

When you release oauth2 and switch openidconnect-rs to version 4 remember to set `default-features = false` ;)