### PR TITLE
Replace failure with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ nightly = []
 [dependencies]
 base64 = "0.12"
 chrono = "0.4"
-failure = "0.1"
-failure_derive = "0.1"
+thiserror = "1.0"
 http = "0.2"
 itertools = "0.9"
 log = "0.4"
@@ -44,3 +43,4 @@ env_logger = "0.7"
 pretty_assertions = "0.6"
 reqwest_ = { package = "reqwest", features = ["blocking", "rustls-tls"], version = "0.10", default-features = false }
 retry = "1.0"
+anyhow = "1.0"

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -19,7 +19,6 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use std::process::exit;
 
-use failure::Fail;
 use url::Url;
 
 use openidconnect::core::{
@@ -31,12 +30,12 @@ use openidconnect::{
     OAuth2TokenResponse, RedirectUrl, Scope,
 };
 
-fn handle_error<T: Fail>(fail: &T, msg: &'static str) {
+fn handle_error<T: std::error::Error>(fail: &T, msg: &'static str) {
     let mut err_msg = format!("ERROR: {}", msg);
-    let mut cur_fail: Option<&dyn Fail> = Some(fail);
+    let mut cur_fail: Option<&dyn std::error::Error> = Some(fail);
     while let Some(cause) = cur_fail {
         err_msg += &format!("\n    caused by: {}", cause);
-        cur_fail = cause.cause();
+        cur_fail = cause.source();
     }
     println!("{}", err_msg);
     exit(1);

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -317,7 +317,7 @@ where
     ) -> Result<Self, DiscoveryError<RE>>
     where
         HC: Fn(HttpRequest) -> Result<HttpResponse, RE>,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         let discovery_url = issuer_url
             .join(CONFIG_URL_SUFFIX)
@@ -345,7 +345,7 @@ where
     where
         F: Future<Output = Result<HttpResponse, RE>>,
         HC: Fn(HttpRequest) -> F + 'static,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         let discovery_url = issuer_url
             .join(CONFIG_URL_SUFFIX)
@@ -380,7 +380,7 @@ where
         discovery_response: HttpResponse,
     ) -> Result<Self, DiscoveryError<RE>>
     where
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         if discovery_response.status_code != StatusCode::OK {
             return Err(DiscoveryError::Response(
@@ -433,7 +433,7 @@ where
 #[non_exhaustive]
 pub enum DiscoveryError<RE>
 where
-    RE: std::error::Error + Send + Sync + 'static,
+    RE: std::error::Error + 'static,
 {
     ///
     /// An unexpected error occurred.

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::marker::PhantomData;
 
-use failure::Fail;
+use thiserror::Error;
 use http::header::{HeaderValue, ACCEPT};
 use http::method::Method;
 use http::status::StatusCode;
@@ -317,7 +317,7 @@ where
     ) -> Result<Self, DiscoveryError<RE>>
     where
         HC: Fn(HttpRequest) -> Result<HttpResponse, RE>,
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         let discovery_url = issuer_url
             .join(CONFIG_URL_SUFFIX)
@@ -345,7 +345,7 @@ where
     where
         F: Future<Output = Result<HttpResponse, RE>>,
         HC: Fn(HttpRequest) -> F + 'static,
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         let discovery_url = issuer_url
             .join(CONFIG_URL_SUFFIX)
@@ -380,7 +380,7 @@ where
         discovery_response: HttpResponse,
     ) -> Result<Self, DiscoveryError<RE>>
     where
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         if discovery_response.status_code != StatusCode::OK {
             return Err(DiscoveryError::Response(
@@ -429,42 +429,42 @@ where
 ///
 /// Error retrieving provider metadata.
 ///
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum DiscoveryError<RE>
 where
-    RE: Fail,
+    RE: std::error::Error + Send + Sync + 'static,
 {
     ///
     /// An unexpected error occurred.
     ///
-    #[fail(display = "Other error: {}", _0)]
+    #[error("Other error: {0}")]
     Other(String),
     ///
     /// Failed to parse server response.
     ///
-    #[fail(display = "Failed to parse server response")]
-    Parse(#[cause] serde_json::Error),
+    #[error("Failed to parse server response")]
+    Parse(#[source] serde_json::Error),
     ///
     /// An error occurred while sending the request or receiving the response (e.g., network
     /// connectivity failed).
     ///
-    #[fail(display = "Request failed")]
-    Request(#[cause] RE),
+    #[error("Request failed")]
+    Request(#[source] RE),
     ///
     /// Server returned an invalid response.
     ///
-    #[fail(display = "Server returned invalid response: {}", _2)]
+    #[error("Server returned invalid response: {2}")]
     Response(StatusCode, Vec<u8>, String),
     ///
     /// Failed to parse discovery URL from issuer URL.
     ///
-    #[fail(display = "Failed to parse URL")]
-    UrlParse(#[cause] url::ParseError),
+    #[error("Failed to parse URL")]
+    UrlParse(#[source] url::ParseError),
     ///
     /// Failed to validate provider metadata.
     ///
-    #[fail(display = "Validation error: {}", _0)]
+    #[error("Validation error: {0}")]
     Validation(String),
 }
 

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -7,6 +7,7 @@ use base64;
 use serde::de::{DeserializeOwned, Error as _, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json;
+use thiserror::Error;
 
 use super::{
     JsonWebKey, JsonWebKeyId, JsonWebKeyType, JsonWebKeyUse, JweContentEncryptionAlgorithm,
@@ -178,19 +179,19 @@ where
 ///
 /// Error creating a JSON Web Token.
 ///
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum JsonWebTokenError {
     ///
     /// Failed to serialize JWT.
     ///
-    #[fail(display = "Failed to serialize JWT")]
-    SerializationError(#[cause] serde_json::Error),
+    #[error("Failed to serialize JWT")]
+    SerializationError(#[source] serde_json::Error),
     ///
     /// Failed to sign JWT.
     ///
-    #[fail(display = "Failed to sign JWT")]
-    SigningError(#[cause] SigningError),
+    #[error("Failed to sign JWT")]
+    SigningError(#[source] SigningError),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,14 +58,14 @@
 //!    Synchronous HTTP clients should implement the following trait:
 //!    ```ignore
 //!    FnOnce(HttpRequest) -> Result<HttpResponse, RE>
-//!    where RE: std::error::Error + Send + Sync + 'static
+//!    where RE: std::error::Error + 'static
 //!
 //!    Async/await `futures` 0.3 HTTP clients should implement the following trait:
 //!    ```ignore
 //!    FnOnce(HttpRequest) -> F
 //!    where
-//!      RE: std::error::Error + Send + Sync + 'static
 //!      F: Future<Output = Result<HttpResponse, RE>>,
+//!      RE: std::error::Error + 'static
 //!    ```
 //!
 //! # OpenID Connect Relying Party (Client) Interface
@@ -464,10 +464,11 @@
 //! # #[cfg(feature = "reqwest-010")]
 //! use openidconnect::reqwest::async_http_client;
 //! use url::Url;
+//! use anyhow::anyhow;
 //!
 //!
 //! # #[cfg(feature = "reqwest-010")]
-//! # async fn err_wrapper() -> Result<(), dyn std::error::Error> {
+//! # async fn err_wrapper() -> Result<(), anyhow::Error> {
 //! // Use OpenID Connect Discovery to fetch the provider metadata.
 //! use openidconnect::{OAuth2TokenResponse, TokenResponse};
 //! let provider_metadata = CoreProviderMetadata::discover_async(
@@ -524,7 +525,7 @@
 //! // Extract the ID token claims after verifying its authenticity and nonce.
 //! let id_token = token_response
 //!   .id_token()
-//!   .ok_or_else(|| failure::format_err!("Server did not return an ID token"))?;
+//!   .ok_or_else(|| anyhow!("Server did not return an ID token"))?;
 //! let claims = id_token.claims(&client.id_token_verifier(), &nonce)?;
 //!
 //! // Verify the access token hash to ensure that the access token hasn't been substituted for
@@ -535,7 +536,7 @@
 //!         &id_token.signing_alg()?
 //!     )?;
 //!     if actual_access_token_hash != *expected_access_token_hash {
-//!         return Err(failure::Error::from_boxed_compat("Invalid access token".into()));
+//!         return Err(anyhow!("Invalid access token"));
 //!     }
 //! }
 //!

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -469,7 +469,7 @@ where
     >
     where
         HC: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         self.prepare_registration(registration_endpoint)
             .and_then(|http_request| {
@@ -493,7 +493,7 @@ where
     where
         F: Future<Output = Result<HttpResponse, RE>>,
         HC: FnOnce(HttpRequest) -> F,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         let http_request = self.prepare_registration(registration_endpoint)?;
         let http_response = http_client(http_request)
@@ -507,7 +507,7 @@ where
         registration_endpoint: &RegistrationUrl,
     ) -> Result<HttpRequest, ClientRegistrationError<ET, RE>>
     where
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         let request_json = serde_json::to_string(self.client_metadata())
             .map_err(ClientRegistrationError::Serialize)?
@@ -541,7 +541,7 @@ where
         ClientRegistrationError<ET, RE>,
     >
     where
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         // TODO: check for WWW-Authenticate response header if bearer auth was used (see
         //   https://tools.ietf.org/html/rfc6750#section-3)
@@ -857,8 +857,8 @@ pub trait RegisterErrorResponseType: ErrorResponseType + 'static {}
 #[non_exhaustive]
 pub enum ClientRegistrationError<T, RE>
 where
-    RE: std::error::Error + Send + Sync + 'static,
-    T: RegisterErrorResponseType + Send + Sync,
+    RE: std::error::Error + 'static,
+    T: RegisterErrorResponseType,
 {
     ///
     /// An unexpected error occurred.

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use failure::Fail;
+use thiserror::Error;
 use http::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE};
 use http::method::Method;
 use http::status::StatusCode;
@@ -469,7 +469,7 @@ where
     >
     where
         HC: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         self.prepare_registration(registration_endpoint)
             .and_then(|http_request| {
@@ -493,7 +493,7 @@ where
     where
         F: Future<Output = Result<HttpResponse, RE>>,
         HC: FnOnce(HttpRequest) -> F,
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         let http_request = self.prepare_registration(registration_endpoint)?;
         let http_response = http_client(http_request)
@@ -507,7 +507,7 @@ where
         registration_endpoint: &RegistrationUrl,
     ) -> Result<HttpRequest, ClientRegistrationError<ET, RE>>
     where
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         let request_json = serde_json::to_string(self.client_metadata())
             .map_err(ClientRegistrationError::Serialize)?
@@ -541,7 +541,7 @@ where
         ClientRegistrationError<ET, RE>,
     >
     where
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         // TODO: check for WWW-Authenticate response header if bearer auth was used (see
         //   https://tools.ietf.org/html/rfc6750#section-3)
@@ -853,43 +853,43 @@ pub trait RegisterErrorResponseType: ErrorResponseType + 'static {}
 ///
 /// Error registering a client.
 ///
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ClientRegistrationError<T, RE>
 where
-    RE: Fail,
+    RE: std::error::Error + Send + Sync + 'static,
     T: RegisterErrorResponseType + Send + Sync,
 {
     ///
     /// An unexpected error occurred.
     ///
-    #[fail(display = "Other error: {}", _0)]
+    #[error("Other error: {0}")]
     Other(String),
     ///
     /// Failed to parse server response.
     ///
-    #[fail(display = "Failed to parse server response")]
-    Parse(#[cause] serde_json::Error),
+    #[error("Failed to parse server response")]
+    Parse(#[source] serde_json::Error),
     ///
     /// An error occurred while sending the request or receiving the response (e.g., network
     /// connectivity failed).
     ///
-    #[fail(display = "Request failed")]
-    Request(#[cause] RE),
+    #[error("Request failed")]
+    Request(#[source] RE),
     ///
     /// Server returned an invalid response.
     ///
-    #[fail(display = "Server returned invalid response: {}", _2)]
+    #[error("Server returned invalid response: {2}")]
     Response(StatusCode, Vec<u8>, String),
     ///
     /// Failed to serialize client metadata.
     ///
-    #[fail(display = "Failed to serialize client metadata")]
-    Serialize(#[cause] serde_json::Error),
+    #[error("Failed to serialize client metadata")]
+    Serialize(#[source] serde_json::Error),
     ///
     /// Server returned an error.
     ///
-    #[fail(display = "Server returned error")]
+    #[error("Server returned error")]
     ServerResponse(StandardErrorResponse<T>),
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use base64;
-use failure::Fail;
+use thiserror::Error;
 use http::header::{HeaderValue, ACCEPT};
 use http::method::Method;
 use http::status::StatusCode;
@@ -198,17 +198,17 @@ pub trait GrantType: Debug + DeserializeOwned + Serialize + 'static {}
 ///
 /// Error signing a message.
 ///
-#[derive(Clone, Debug, Fail, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 #[non_exhaustive]
 pub enum SigningError {
     /// Failed to sign the message using the given key and parameters.
-    #[fail(display = "Crypto error")]
+    #[error("Crypto error")]
     CryptoError,
     /// Unsupported signature algorithm.
-    #[fail(display = "Unsupported signature algorithm: {}", _0)]
+    #[error("Unsupported signature algorithm: {0}")]
     UnsupportedAlg(String),
     /// An unexpected error occurred.
-    #[fail(display = "Other error: {}", _0)]
+    #[error("Other error: {0}")]
     Other(String),
 }
 
@@ -752,7 +752,7 @@ where
     ) -> Result<Self, DiscoveryError<RE>>
     where
         HC: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         http_client(Self::fetch_request(url))
             .map_err(DiscoveryError::Request)
@@ -770,7 +770,7 @@ where
     where
         F: Future<Output = Result<HttpResponse, RE>>,
         HC: FnOnce(HttpRequest) -> F,
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         http_client(Self::fetch_request(url))
             .await
@@ -791,7 +791,7 @@ where
 
     fn fetch_response<RE>(http_response: HttpResponse) -> Result<Self, DiscoveryError<RE>>
     where
-        RE: Fail,
+        RE: std::error::Error + Send + Sync + 'static,
     {
         if http_response.status_code != StatusCode::OK {
             return Err(DiscoveryError::Response(
@@ -962,7 +962,7 @@ new_url_type![
 
 ///
 /// Informs the Authorization Server of the desired authorization processing flow, including what
-/// parameters are returned from the endpoints used.  
+/// parameters are returned from the endpoints used.
 ///
 /// See [OAuth 2.0 Multiple Response Type Encoding Practices](
 ///     http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseTypesAndModes)

--- a/src/types.rs
+++ b/src/types.rs
@@ -752,7 +752,7 @@ where
     ) -> Result<Self, DiscoveryError<RE>>
     where
         HC: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         http_client(Self::fetch_request(url))
             .map_err(DiscoveryError::Request)
@@ -770,7 +770,7 @@ where
     where
         F: Future<Output = Result<HttpResponse, RE>>,
         HC: FnOnce(HttpRequest) -> F,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         http_client(Self::fetch_request(url))
             .await
@@ -791,7 +791,7 @@ where
 
     fn fetch_response<RE>(http_response: HttpResponse) -> Result<Self, DiscoveryError<RE>>
     where
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         if http_response.status_code != StatusCode::OK {
             return Err(DiscoveryError::Response(

--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -63,7 +63,7 @@ where
         AC: AdditionalClaims,
         GC: GenderClaim,
         HC: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         http_client(self.prepare_request())
             .map_err(UserInfoError::Request)
@@ -83,7 +83,7 @@ where
         C: FnOnce(HttpRequest) -> F,
         F: Future<Output = Result<HttpResponse, RE>>,
         GC: GenderClaim,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         let http_request = self.prepare_request();
         let http_response = http_client(http_request)
@@ -115,7 +115,7 @@ where
     where
         AC: AdditionalClaims,
         GC: GenderClaim,
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         if http_response.status_code != StatusCode::OK {
             return Err(UserInfoError::Response(
@@ -229,7 +229,7 @@ where
         expected_subject: Option<&SubjectIdentifier>,
     ) -> Result<Self, UserInfoError<RE>>
     where
-        RE: std::error::Error + Send + Sync + 'static,
+        RE: std::error::Error + 'static,
     {
         let user_info = serde_json::from_slice::<UserInfoClaimsImpl<AC, GC>>(&user_info_json)
             .map_err(UserInfoError::Parse)?;
@@ -449,7 +449,7 @@ new_url_type![
 #[non_exhaustive]
 pub enum UserInfoError<RE>
 where
-    RE: std::error::Error + Send + Sync + 'static,
+    RE: std::error::Error + 'static,
 {
     ///
     /// Failed to verify user info claims.

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -10,6 +10,7 @@ use oauth2::{ClientId, ClientSecret};
 use ring::constant_time::verify_slices_are_equal;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use thiserror::Error;
 
 use crate::jwt::{JsonWebToken, JsonWebTokenJsonPayloadSerde};
 use crate::user_info::UserInfoClaimsImpl;
@@ -31,63 +32,63 @@ pub(crate) trait IssuerClaim {
 ///
 /// Error verifying claims.
 ///
-#[derive(Clone, Debug, Fail, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 #[non_exhaustive]
 pub enum ClaimsVerificationError {
     /// Claims have expired.
-    #[fail(display = "Expired: {}", _0)]
+    #[error("Expired: {0}")]
     Expired(String),
     /// Audience claim is invalid.
-    #[fail(display = "Invalid audiences: {}", _0)]
+    #[error("Invalid audiences: {0}")]
     InvalidAudience(String),
     /// Authorization context class reference (`acr`) claim is invalid.
-    #[fail(display = "Invalid authorization context class reference: {}", _0)]
+    #[error("Invalid authorization context class reference: {0}")]
     InvalidAuthContext(String),
     /// User authenticated too long ago.
-    #[fail(display = "Invalid authentication time: {}", _0)]
+    #[error("Invalid authentication time: {0}")]
     InvalidAuthTime(String),
     /// Issuer claim is invalid.
-    #[fail(display = "Invalid issuer: {}", _0)]
+    #[error("Invalid issuer: {0}")]
     InvalidIssuer(String),
     /// Nonce is invalid.
-    #[fail(display = "Invalid nonce: {}", _0)]
+    #[error("Invalid nonce: {0}")]
     InvalidNonce(String),
     /// Subject claim is invalid.
-    #[fail(display = "Invalid subject: {}", _0)]
+    #[error("Invalid subject: {0}")]
     InvalidSubject(String),
     /// No signature present but claims must be signed.
-    #[fail(display = "Claims must be signed")]
+    #[error("Claims must be signed")]
     NoSignature,
     /// An unexpected error occurred.
-    #[fail(display = "{}", _0)]
+    #[error("{0}")]
     Other(String),
     /// Failed to verify the claims signature.
-    #[fail(display = "Signature verification failed")]
-    SignatureVerification(#[cause] SignatureVerificationError),
+    #[error("Signature verification failed")]
+    SignatureVerification(#[source] SignatureVerificationError),
     /// Unsupported argument or value.
-    #[fail(display = "Unsupported: {}", _0)]
+    #[error("Unsupported: {0}")]
     Unsupported(String),
 }
 
 ///
 /// Error verifying claims signature.
 ///
-#[derive(Clone, Debug, Fail, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 #[non_exhaustive]
 pub enum SignatureVerificationError {
     /// More than one key matches the supplied key constraints (e.g., key ID).
-    #[fail(display = "Ambiguous key identification: {}", _0)]
+    #[error("Ambiguous key identification: {0}")]
     AmbiguousKeyId(String),
     /// Invalid signature for the supplied claims and signing key.
-    #[fail(display = "Crypto error: {}", _0)]
+    #[error("Crypto error: {0}")]
     CryptoError(String),
     /// The supplied signature algorithm is disallowed by the verifier.
-    #[fail(display = "Disallowed signature algorithm: {}", _0)]
+    #[error("Disallowed signature algorithm: {0}")]
     DisallowedAlg(String),
     /// The supplied key cannot be used in this context. This may occur if the key type does not
     /// match the signature type (e.g., an RSA key used to validate an HMAC) or the JWK usage
     /// disallows signatures.
-    #[fail(display = "Invalid cryptographic key: {}", _0)]
+    #[error("Invalid cryptographic key: {0}")]
     InvalidKey(String),
     /// The signing key needed for verifying the
     /// [JSON Web Token](https://tools.ietf.org/html/rfc7519)'s signature/MAC could not be found.
@@ -104,13 +105,13 @@ pub enum SignatureVerificationError {
     /// This error can also occur if the identified
     /// [JSON Web Key](https://tools.ietf.org/html/rfc7517) is of the wrong type (e.g., an RSA key
     /// when the JOSE header specifies an ECDSA algorithm) or does not support signing.
-    #[fail(display = "No matching key found")]
+    #[error("No matching key found")]
     NoMatchingKey,
     /// Unsupported signature algorithm.
-    #[fail(display = "Unsupported signature algorithm: {}", _0)]
+    #[error("Unsupported signature algorithm: {0}")]
     UnsupportedAlg(String),
     /// An unexpected error occurred.
-    #[fail(display = "Other error: {}", _0)]
+    #[error("Other error: {0}")]
     Other(String),
 }
 

--- a/tests/rp_certification_code.rs
+++ b/tests/rp_certification_code.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::expect_fun_call)]
 extern crate env_logger;
-extern crate failure;
 extern crate http;
 #[macro_use]
 extern crate log;

--- a/tests/rp_certification_dynamic.rs
+++ b/tests/rp_certification_dynamic.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::cognitive_complexity)]
 extern crate env_logger;
-extern crate failure;
 #[macro_use]
 extern crate log;
 extern crate openidconnect;


### PR DESCRIPTION
This PR is based on @mettke's and finalizes the move to oauth4 with removing `failure` as a dependency and replacing it with `thiserror` and `anyhow`(in the docs).

To make this work, i had to change `oauth2` from version 3 to the github `main`-branch and as result of this i also had to remove the `futures-03`-feature. I guess you want to wait with merging this, until you have released an `alpha`.version of `oauth2` to crates.io. Just let me know how i should proceed from here on.