### PR TITLE
Client credentials grant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -961,10 +961,10 @@ where
         self.oauth2_client.exchange_password(username, password)
 	}
 	
-	///
+    ///
     /// Creates a request builder for exchanging client credentials for an access token.
     ///
-    /// See https://tools.ietf.org/html/rfc6749#section-6
+    /// See https://tools.ietf.org/html/rfc6749#section-4.4
     ///
     pub fn exchange_client_credentials<'a, 'b>(
         &'a self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,7 +574,7 @@ use std::time::Duration;
 pub use oauth2::{
     AccessToken, AuthType, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CodeTokenRequest,
     CsrfToken, EmptyExtraTokenFields, ErrorResponse, ErrorResponseType, ExtraTokenFields,
-    HttpRequest, HttpResponse, PasswordTokenRequest, PkceCodeChallenge, PkceCodeChallengeMethod,
+    HttpRequest, HttpResponse, PasswordTokenRequest, ClientCredentialsTokenRequest, PkceCodeChallenge, PkceCodeChallengeMethod,
     PkceCodeVerifier, RedirectUrl, RefreshToken, RefreshTokenRequest, RequestTokenError,
     ResourceOwnerPassword, ResourceOwnerUsername, Scope, StandardErrorResponse,
     StandardTokenResponse, TokenResponse as OAuth2TokenResponse, TokenType, TokenUrl,
@@ -959,6 +959,20 @@ where
         'a: 'b,
     {
         self.oauth2_client.exchange_password(username, password)
+	}
+	
+	///
+    /// Creates a request builder for exchanging client credentials for an access token.
+    ///
+    /// See https://tools.ietf.org/html/rfc6749#section-6
+    ///
+    pub fn exchange_client_credentials<'a, 'b>(
+        &'a self,
+    ) -> ClientCredentialsTokenRequest<'b, TE, TR, TT>
+    where
+        'a: 'b,
+    {
+        self.oauth2_client.exchange_client_credentials()
     }
 
     ///


### PR DESCRIPTION
Hello ! First of all, thank you very much for that nice crate you made !
I just thought the `exchange_client_credentials` was missing from the `openidconnect::Client`.
