### PR TITLE
Minimal support for exposing new oauth2-rs crate token introspection and revocation features (resolves #37).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0"
 http = "0.2"
 itertools = "0.9"
 log = "0.4"
-oauth2 = { version = "=4.0.0-alpha.4", default-features = false }
+oauth2 = { version = "=4.0.0-alpha.5", default-features = false }
 rand = "0.7"
 ring = "0.16"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openidconnect"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 authors = ["David A. Ramos <ramos@cs.stanford.edu>"]
 description = "OpenID Connect library"
 license = "MIT"
@@ -27,7 +27,7 @@ thiserror = "1.0"
 http = "0.2"
 itertools = "0.9"
 log = "0.4"
-oauth2 = { version = "4.0.0-alpha.3", default-features = false }
+oauth2 = { version = "4.0.0-alpha.4", default-features = false }
 rand = "0.7"
 ring = "0.16"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0"
 http = "0.2"
 itertools = "0.9"
 log = "0.4"
-oauth2 = { version = "=4.0.0-alpha.5", default-features = false }
+oauth2 = { version = "=4.0.0-alpha.6", default-features = false }
 rand = "0.7"
 ring = "0.16"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openidconnect"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.3"
 authors = ["David A. Ramos <ramos@cs.stanford.edu>"]
 description = "OpenID Connect library"
 license = "MIT"
@@ -27,7 +27,7 @@ thiserror = "1.0"
 http = "0.2"
 itertools = "0.9"
 log = "0.4"
-oauth2 = { version = "4.0.0-alpha.4", default-features = false }
+oauth2 = { version = "=4.0.0-alpha.4", default-features = false }
 rand = "0.7"
 ring = "0.16"
 serde = "1.0"

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -234,7 +234,7 @@ fn main() {
 
             client
                 .revoke_token(token_to_revoke)
-                .unwrap()
+                .expect("no revocation_uri configured")
                 .request(http_client)
                 .unwrap_or_else(|err| {
                     handle_error(&err, "Failed to contact token revocation endpoint");

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -19,13 +19,20 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use std::process::exit;
 
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-use openidconnect::core::{CoreClient, CoreIdTokenClaims, CoreIdTokenVerifier, CoreResponseType};
-use openidconnect::{reqwest::http_client, RevocationUrl};
+use openidconnect::core::{
+    CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClient, CoreClientAuthMethod, CoreGrantType,
+    CoreIdTokenClaims, CoreIdTokenVerifier, CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse,
+    CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm, CoreJwsSigningAlgorithm,
+    CoreResponseMode, CoreResponseType, CoreRevocableToken, CoreSubjectIdentifierType,
+};
+use openidconnect::reqwest::http_client;
 use openidconnect::{
-    AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce,
-    OAuth2TokenResponse, RedirectUrl, Scope,
+    AdditionalProviderMetadata, AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret,
+    CsrfToken, IssuerUrl, Nonce, OAuth2TokenResponse, ProviderMetadata, RedirectUrl, RevocationUrl,
+    Scope,
 };
 
 fn handle_error<T: std::error::Error>(fail: &T, msg: &'static str) {
@@ -41,16 +48,6 @@ fn handle_error<T: std::error::Error>(fail: &T, msg: &'static str) {
 
 // Teach openidconnect-rs about the Google custom extension to the OpenID Discovery response
 // that we can use as the RFC 7009 OAuth 2.0 Token Revocation endpoint.
-use openidconnect::core::{
-    CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClientAuthMethod, CoreGrantType,
-    CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse, CoreJweContentEncryptionAlgorithm,
-    CoreJweKeyManagementAlgorithm, CoreJwsSigningAlgorithm, CoreResponseMode, CoreRevocableToken,
-    CoreSubjectIdentifierType,
-};
-use openidconnect::{AdditionalProviderMetadata, ProviderMetadata};
-
-use serde::{Deserialize, Serialize};
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct RevocationEndpointProviderMetadata {
     revocation_endpoint: String,

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -88,8 +88,16 @@ fn main() {
         IssuerUrl::new("https://accounts.google.com".to_string()).expect("Invalid issuer URL");
 
     // Fetch Google's OpenID Connect discovery document.
-    // Note: if we don't care about token revocation we can simply use CoreProviderMetadata here
-    // instead of GoogleProviderMetadata.
+    //
+    // Note: If we don't care about token revocation we can simply use CoreProviderMetadata here
+    // instead of GoogleProviderMetadata. If instead we wanted to optionally use the token
+    // revocation endpoint if it seems to be supported we could do something like this:
+    //   #[derive(Clone, Debug, Deserialize, Serialize)]
+    //   struct AllOtherProviderMetadata(HashMap<String, serde_json::Value>);
+    //   impl AdditionalClaims for AllOtherProviderMetadata {}
+    // And then test for the presence of "revocation_endpoint" in the map returned by a call to
+    // .additional_metadata().
+
     let provider_metadata = GoogleProviderMetadata::discover(&issuer_url, http_client)
         .unwrap_or_else(|err| {
             handle_error(&err, "Failed to discover OpenID Provider");

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -46,8 +46,9 @@ fn handle_error<T: std::error::Error>(fail: &T, msg: &'static str) {
     exit(1);
 }
 
-// Teach openidconnect-rs about the Google custom extension to the OpenID Discovery response
-// that we can use as the RFC 7009 OAuth 2.0 Token Revocation endpoint.
+// Teach openidconnect-rs about a Google custom extension to the OpenID Discovery response that we can use as the RFC
+// 7009 OAuth 2.0 Token Revocation endpoint. For more information about the Google specific Discovery response see the
+// Google OpenID Connect service documentation at: https://developers.google.com/identity/protocols/oauth2/openid-connect#discovery
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct RevocationEndpointProviderMetadata {
     revocation_endpoint: String,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,7 +6,7 @@ pub use oauth2::basic::{
     BasicRequestTokenError as CoreRequestTokenError,
     BasicRevocationErrorResponse as CoreRevocationErrorResponse, BasicTokenType as CoreTokenType,
 };
-pub use oauth2::revocation::StandardRevocableToken as CoreRevocableToken;
+pub use oauth2::StandardRevocableToken as CoreRevocableToken;
 use oauth2::{
     EmptyExtraTokenFields, ErrorResponseType, ResponseType as OAuth2ResponseType,
     StandardErrorResponse, StandardTokenIntrospectionResponse, StandardTokenResponse,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,12 +3,15 @@ use std::ops::Deref;
 
 pub use oauth2::basic::{
     BasicErrorResponseType as CoreErrorResponseType,
-    BasicRequestTokenError as CoreRequestTokenError, BasicTokenType as CoreTokenType,
+    BasicRequestTokenError as CoreRequestTokenError,
+    BasicRevocationErrorResponse as CoreRevocationErrorResponse, BasicTokenType as CoreTokenType,
 };
+pub use oauth2::revocation::StandardRevocableToken as CoreRevocableToken;
 use oauth2::{
     EmptyExtraTokenFields, ErrorResponseType, ResponseType as OAuth2ResponseType,
-    StandardErrorResponse, StandardTokenResponse,
+    StandardErrorResponse, StandardTokenIntrospectionResponse, StandardTokenResponse,
 };
+
 use serde::{Deserialize, Serialize};
 
 use crate::registration::{
@@ -36,6 +39,12 @@ mod crypto;
 mod jwk;
 
 ///
+/// OpenID Connect Core token introspection response.
+///
+pub type CoreTokenIntrospectionResponse =
+    StandardTokenIntrospectionResponse<EmptyExtraTokenFields, CoreTokenType>;
+
+///
 /// OpenID Connect Core authentication flows.
 ///
 pub type CoreAuthenticationFlow = AuthenticationFlow<CoreResponseType>;
@@ -56,6 +65,9 @@ pub type CoreClient = Client<
     StandardErrorResponse<CoreErrorResponseType>,
     CoreTokenResponse,
     CoreTokenType,
+    CoreTokenIntrospectionResponse,
+    CoreRevocableToken,
+    CoreRevocationErrorResponse,
 >;
 
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,6 +709,28 @@ pub enum AuthenticationFlow<RT: ResponseType> {
 }
 
 /// OpenID Connect client.
+///
+/// # Error Types
+///
+/// To enable compile time verification that only the correct and complete set of errors for the `Client` function being
+/// invoked are exposed to the caller, the `Client` type is specialized on multiple implementations of the
+/// [`ErrorResponse`] trait. The exact [`ErrorResponse`] implementation returned varies by the RFC that the invoked
+/// `Client` function implements:
+///
+///   - Generic type `TE` (aka Token Error) for errors defined by [RFC 6749 OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749).
+///   - Generic type `TRE` (aka Token Revocation Error) for errors defined by [RFC 7009 OAuth 2.0 Token Revocation](https://tools.ietf.org/html/rfc7009).
+///
+/// For example when revoking a token, error code `unsupported_token_type` (from RFC 7009) may be returned:
+/// ```ignore
+/// let revocation_response = client
+///     .revoke_token(AccessToken::new("some token".to_string()).into())
+///     .request(...);
+///
+/// assert!(matches!(res, Err(
+///     RequestTokenError::ServerResponse(err)) if matches!(err.error(),
+///         RevocationErrorResponseType::UnsupportedTokenType)));
+/// ```
+///
 #[derive(Clone, Debug)]
 pub struct Client<AC, AD, GC, JE, JS, JT, JU, K, P, TE, TR, TT, TIR, RT, TRE>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -750,7 +750,6 @@ where
     RT: RevocableToken,
     TRE: ErrorResponse,
 {
-    // FIXME: Add support for OAuth 2 Token Introspection
     oauth2_client: oauth2::Client<TE, TR, TT, TIR, RT, TRE>,
     client_id: ClientId,
     client_secret: Option<ClientSecret>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,7 +792,7 @@ where
     /// Use [`ProviderMetadata::discover`] or
     /// [`ProviderMetadata::discover_async`] to fetch the provider metadata.
     ///
-    pub fn from_provider_metadata<A, CA, CN, CT, G, JK, RM, RT2, S>(
+    pub fn from_provider_metadata<A, CA, CN, CT, G, JK, RM, RS, S>(
         provider_metadata: ProviderMetadata<
             A,
             AD,
@@ -807,7 +807,7 @@ where
             JU,
             K,
             RM,
-            RT2,
+            RS,
             S,
         >,
         client_id: ClientId,
@@ -821,7 +821,7 @@ where
         G: GrantType,
         JK: JweKeyManagementAlgorithm,
         RM: ResponseMode,
-        RT2: ResponseType,
+        RS: ResponseType,
         S: SubjectIdentifierType,
     {
         Self::new(
@@ -943,15 +943,15 @@ where
     /// Similarly, callers should use a fresh, unpredictable `nonce` to help protect against ID
     /// token reuse and forgery.
     ///
-    pub fn authorize_url<NF, RT2, SF>(
+    pub fn authorize_url<NF, RS, SF>(
         &self,
-        authentication_flow: AuthenticationFlow<RT2>,
+        authentication_flow: AuthenticationFlow<RS>,
         state_fn: SF,
         nonce_fn: NF,
-    ) -> AuthorizationRequest<AD, P, RT2>
+    ) -> AuthorizationRequest<AD, P, RS>
     where
         NF: FnOnce() -> Nonce + 'static,
-        RT2: ResponseType,
+        RS: ResponseType,
         SF: FnOnce() -> CsrfToken + 'static,
     {
         let request = AuthorizationRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -585,13 +585,14 @@ use std::time::Duration;
 
 pub use oauth2::{
     AccessToken, AuthType, AuthUrl, AuthorizationCode, ClientCredentialsTokenRequest, ClientId,
-    ClientSecret, CodeTokenRequest, CsrfToken, EmptyExtraTokenFields, ErrorResponse,
-    ErrorResponseType, ExtraTokenFields, HttpRequest, HttpResponse, IntrospectionRequest,
-    IntrospectionUrl, PasswordTokenRequest, PkceCodeChallenge, PkceCodeChallengeMethod,
-    PkceCodeVerifier, RedirectUrl, RefreshToken, RefreshTokenRequest, RequestTokenError,
-    ResourceOwnerPassword, ResourceOwnerUsername, RevocableToken, RevocationRequest, RevocationUrl,
-    Scope, StandardErrorResponse, StandardTokenResponse, TokenIntrospectionResponse,
-    TokenResponse as OAuth2TokenResponse, TokenType, TokenUrl,
+    ClientSecret, CodeTokenRequest, ConfigurationError, CsrfToken, EmptyExtraTokenFields,
+    ErrorResponse, ErrorResponseType, ExtraTokenFields, HttpRequest, HttpResponse,
+    IntrospectionRequest, IntrospectionUrl, PasswordTokenRequest, PkceCodeChallenge,
+    PkceCodeChallengeMethod, PkceCodeVerifier, RedirectUrl, RefreshToken, RefreshTokenRequest,
+    RequestTokenError, ResourceOwnerPassword, ResourceOwnerUsername, RevocableToken,
+    RevocationErrorResponseType, RevocationRequest, RevocationUrl, Scope, StandardErrorResponse,
+    StandardTokenResponse, TokenIntrospectionResponse, TokenResponse as OAuth2TokenResponse,
+    TokenType, TokenUrl,
 };
 
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -855,8 +855,8 @@ where
     ///
     /// Sets the the redirect URL used by the authorization endpoint.
     ///
-    pub fn set_redirect_uri(mut self, redirect_uri: RedirectUrl) -> Self {
-        self.oauth2_client = self.oauth2_client.set_redirect_url(redirect_uri);
+    pub fn set_redirect_uri(mut self, redirect_url: RedirectUrl) -> Self {
+        self.oauth2_client = self.oauth2_client.set_redirect_uri(redirect_url);
         self
     }
 
@@ -864,8 +864,8 @@ where
     /// Sets the introspection URL for contacting the ([RFC 7662](https://tools.ietf.org/html/rfc7662))
     /// introspection endpoint.
     ///
-    pub fn set_introspection_url(mut self, introspection_url: IntrospectionUrl) -> Self {
-        self.oauth2_client = self.oauth2_client.set_introspection_url(introspection_url);
+    pub fn set_introspection_uri(mut self, introspection_url: IntrospectionUrl) -> Self {
+        self.oauth2_client = self.oauth2_client.set_introspection_uri(introspection_url);
         self
     }
 
@@ -874,8 +874,8 @@ where
     ///
     /// See: [`revoke_token()`](Self::revoke_token())
     ///
-    pub fn set_revocation_uri(mut self, revocation_uri: RevocationUrl) -> Self {
-        self.oauth2_client = self.oauth2_client.set_revocation_url(revocation_uri);
+    pub fn set_revocation_uri(mut self, revocation_url: RevocationUrl) -> Self {
+        self.oauth2_client = self.oauth2_client.set_revocation_uri(revocation_url);
         self
     }
 
@@ -1275,8 +1275,8 @@ where
     ///
     /// Overrides the `redirect_url` to the one specified.
     ///
-    pub fn set_redirect_url(mut self, redirect_url: Cow<'a, RedirectUrl>) -> Self {
-        self.inner = self.inner.set_redirect_url(redirect_url);
+    pub fn set_redirect_uri(mut self, redirect_url: Cow<'a, RedirectUrl>) -> Self {
+        self.inner = self.inner.set_redirect_uri(redirect_url);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -721,10 +721,49 @@ pub enum AuthenticationFlow<RT: ResponseType> {
 ///   - Generic type `TRE` (aka Token Revocation Error) for errors defined by [RFC 7009 OAuth 2.0 Token Revocation](https://tools.ietf.org/html/rfc7009).
 ///
 /// For example when revoking a token, error code `unsupported_token_type` (from RFC 7009) may be returned:
-/// ```ignore
-/// let revocation_response = client
+/// ```rust
+/// # use thiserror::Error;
+/// # use http::status::StatusCode;
+/// # use http::header::{HeaderValue, CONTENT_TYPE};
+/// # use oauth2::*;
+/// # use openidconnect::{*, core::*};
+/// # let client = CoreClient::new(
+/// #     ClientId::new("aaa".to_string()),
+/// #     Some(ClientSecret::new("bbb".to_string())),
+/// #     IssuerUrl::new("https://example".to_string()).unwrap(),
+/// #     AuthUrl::new("https://example/authorize".to_string()).unwrap(),
+/// #     Some(TokenUrl::new("https://example/token".to_string()).unwrap()),
+/// #     None,
+/// #     JsonWebKeySet::default(),
+/// # )
+/// # .set_revocation_uri(RevocationUrl::new("https://revocation/url".to_string()).unwrap());
+/// #
+/// # #[derive(Debug, Error)]
+/// # enum FakeError {
+/// #     #[error("error")]
+/// #     Err,
+/// # }
+/// #
+/// # let http_client = |_| -> Result<HttpResponse, FakeError> {
+/// #     Ok(HttpResponse {
+/// #         status_code: StatusCode::BAD_REQUEST,
+/// #         headers: vec![(
+/// #             CONTENT_TYPE,
+/// #             HeaderValue::from_str("application/json").unwrap(),
+/// #         )]
+/// #         .into_iter()
+/// #         .collect(),
+/// #         body: "{\"error\": \"unsupported_token_type\", \"error_description\": \"stuff happened\", \
+/// #                \"error_uri\": \"https://errors\"}"
+/// #             .to_string()
+/// #             .into_bytes(),
+/// #     })
+/// # };
+/// #
+/// let res = client
 ///     .revoke_token(AccessToken::new("some token".to_string()).into())
-///     .request(...);
+///     .unwrap()
+///     .request(http_client);
 ///
 /// assert!(matches!(res, Err(
 ///     RequestTokenError::ServerResponse(err)) if matches!(err.error(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,8 +574,8 @@ extern crate pretty_assertions;
 #[macro_use]
 extern crate serde_derive;
 
-use oauth2::{ConfigurationError, helpers::variant_name};
 use oauth2::ResponseType as OAuth2ResponseType;
+use oauth2::{helpers::variant_name, ConfigurationError};
 use url::Url;
 
 use std::borrow::Cow;
@@ -634,8 +634,7 @@ pub use types::{
     SubjectIdentifier, SubjectIdentifierType, ToSUrl,
 };
 pub use user_info::{
-    UserInfoClaims, UserInfoError, UserInfoJsonWebToken, UserInfoRequest,
-    UserInfoUrl,
+    UserInfoClaims, UserInfoError, UserInfoJsonWebToken, UserInfoRequest, UserInfoUrl,
 };
 use verification::{AudiencesClaim, IssuerClaim};
 pub use verification::{
@@ -793,23 +792,7 @@ where
     /// [`ProviderMetadata::discover_async`] to fetch the provider metadata.
     ///
     pub fn from_provider_metadata<A, CA, CN, CT, G, JK, RM, RS, S>(
-        provider_metadata: ProviderMetadata<
-            A,
-            AD,
-            CA,
-            CN,
-            CT,
-            G,
-            JE,
-            JK,
-            JS,
-            JT,
-            JU,
-            K,
-            RM,
-            RS,
-            S,
-        >,
+        provider_metadata: ProviderMetadata<A, AD, CA, CN, CT, G, JE, JK, JS, JT, JU, K, RM, RS, S>,
         client_id: ClientId,
         client_secret: Option<ClientSecret>,
     ) -> Self
@@ -1089,7 +1072,10 @@ where
     ///
     /// See https://tools.ietf.org/html/rfc7009
     ///
-    pub fn revoke_token(&self, token: RT) -> Result<RevocationRequest<RT, TRE>, ConfigurationError> {
+    pub fn revoke_token(
+        &self,
+        token: RT,
+    ) -> Result<RevocationRequest<RT, TRE>, ConfigurationError> {
         self.oauth2_client.revoke_token(token)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1588,7 +1588,7 @@ mod tests {
             .add_auth_context_value(AuthenticationContextClass::new(
                 "urn:mace:incommon:iap:silver".to_string(),
             ))
-            .set_redirect_url(Cow::Owned(
+            .set_redirect_uri(Cow::Owned(
                 RedirectUrl::new("http://localhost:8888/alternative".to_string()).unwrap(),
             ))
             .url();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,8 +574,8 @@ extern crate pretty_assertions;
 #[macro_use]
 extern crate serde_derive;
 
+use oauth2::helpers::variant_name;
 use oauth2::ResponseType as OAuth2ResponseType;
-use oauth2::{helpers::variant_name, ConfigurationError};
 use url::Url;
 
 use std::borrow::Cow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,7 +575,7 @@ extern crate pretty_assertions;
 extern crate serde_derive;
 
 use oauth2::helpers::variant_name;
-use oauth2::{ResponseType as OAuth2ResponseType};
+use oauth2::ResponseType as OAuth2ResponseType;
 use url::Url;
 
 use std::borrow::Cow;
@@ -586,12 +586,12 @@ use std::time::Duration;
 pub use oauth2::{
     AccessToken, AuthType, AuthUrl, AuthorizationCode, ClientCredentialsTokenRequest, ClientId,
     ClientSecret, CodeTokenRequest, CsrfToken, EmptyExtraTokenFields, ErrorResponse,
-    ErrorResponseType, ExtraTokenFields, HttpRequest, HttpResponse, PasswordTokenRequest,
-    PkceCodeChallenge, PkceCodeChallengeMethod, PkceCodeVerifier, RedirectUrl, RefreshToken,
-    RefreshTokenRequest, RequestTokenError, ResourceOwnerPassword, ResourceOwnerUsername, Scope,
-    StandardErrorResponse, StandardTokenResponse, TokenResponse as OAuth2TokenResponse, TokenType,
-    TokenUrl, TokenIntrospectionResponse, IntrospectionRequest, IntrospectionUrl, RevocableToken, RevocationUrl,
-    RevocationRequest,
+    ErrorResponseType, ExtraTokenFields, HttpRequest, HttpResponse, IntrospectionRequest,
+    IntrospectionUrl, PasswordTokenRequest, PkceCodeChallenge, PkceCodeChallengeMethod,
+    PkceCodeVerifier, RedirectUrl, RefreshToken, RefreshTokenRequest, RequestTokenError,
+    ResourceOwnerPassword, ResourceOwnerUsername, RevocableToken, RevocationRequest, RevocationUrl,
+    Scope, StandardErrorResponse, StandardTokenResponse, TokenIntrospectionResponse,
+    TokenResponse as OAuth2TokenResponse, TokenType, TokenUrl,
 };
 
 ///
@@ -729,8 +729,7 @@ where
     TRE: ErrorResponse,
 {
     // FIXME: Add support for OAuth 2 Token Introspection
-    oauth2_client:
-        oauth2::Client<TE, TR, TT, TIR, RT, TRE>,
+    oauth2_client: oauth2::Client<TE, TR, TT, TIR, RT, TRE>,
     client_id: ClientId,
     client_secret: Option<ClientSecret>,
     issuer: IssuerUrl,
@@ -794,7 +793,23 @@ where
     /// [`ProviderMetadata::discover_async`] to fetch the provider metadata.
     ///
     pub fn from_provider_metadata<A, CA, CN, CT, G, JK, RM, RT2, S>(
-        provider_metadata: ProviderMetadata<A, AD, CA, CN, CT, G, JE, JK, JS, JT, JU, K, RM, RT2, S>,
+        provider_metadata: ProviderMetadata<
+            A,
+            AD,
+            CA,
+            CN,
+            CT,
+            G,
+            JE,
+            JK,
+            JS,
+            JT,
+            JU,
+            K,
+            RM,
+            RT2,
+            S,
+        >,
         client_id: ClientId,
         client_secret: Option<ClientSecret>,
     ) -> Self
@@ -858,7 +873,7 @@ where
         self.oauth2_client = self.oauth2_client.set_revocation_url(revocation_uri);
         self
     }
-        
+
     ///
     /// Enables the `openid` scope to be requested automatically.
     ///
@@ -1075,10 +1090,7 @@ where
     ///
     /// See https://tools.ietf.org/html/rfc7009
     ///
-    pub fn revoke_token(
-        &self,
-        token: RT
-    ) -> RevocationRequest<RT, TRE> {
+    pub fn revoke_token(&self, token: RT) -> RevocationRequest<RT, TRE> {
         self.oauth2_client.revoke_token(token)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,6 +708,7 @@ pub enum AuthenticationFlow<RT: ResponseType> {
     Hybrid(Vec<RT>),
 }
 
+///
 /// OpenID Connect client.
 ///
 /// # Error Types

--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -29,7 +29,7 @@ use crate::{
 ///
 /// User info request.
 ///
-pub struct UserInfoRequest<JE, JS, JT, JU, K>
+pub struct UserInfoRequest<'a, JE, JS, JT, JU, K>
 where
     JE: JweContentEncryptionAlgorithm<JT>,
     JS: JwsSigningAlgorithm<JT>,
@@ -37,12 +37,12 @@ where
     JU: JsonWebKeyUse,
     K: JsonWebKey<JS, JT, JU>,
 {
-    pub(super) url: UserInfoUrl,
+    pub(super) url: &'a UserInfoUrl,
     pub(super) access_token: AccessToken,
     pub(super) require_signed_response: bool,
     pub(super) signed_response_verifier: UserInfoVerifier<'static, JE, JS, JT, JU, K>,
 }
-impl<JE, JS, JT, JU, K> UserInfoRequest<JE, JS, JT, JU, K>
+impl<'a, JE, JS, JT, JU, K> UserInfoRequest<'a, JE, JS, JT, JU, K>
 where
     JE: JweContentEncryptionAlgorithm<JT>,
     JS: JwsSigningAlgorithm<JT>,
@@ -477,13 +477,6 @@ where
     #[error("Other error: {0}")]
     Other(String),
 }
-
-///
-/// The OpenID Connect Provider has no associated user info endpoint.
-///
-#[derive(Debug, Error)]
-#[error("No user info endpoint specified")]
-pub struct NoUserInfoEndpoint;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This is a minimal first effort to address #37 now that support for token revocation was merged into `oauth2-rs` release `4.0.0-alpha.4`.

`cargo fmt` has NOT been applied to the code as doing so causes:

```
        provider_metadata: ProviderMetadata<A, AD, CA, CN, CT, G, JE, JK, JS, JT, JU, K, RM, RT2, S>,
```

To become 10 or so lines with `A`, `AD` etc each on their own line which is ugly, and I didn't find a way to tell `rustfmt` to ignore just that one change (the `skip` support in `rustfmt` cannot be used for a single parameter of a function).

This PR lacks additional richer documentation, e.g. example code, in particular referencing the fact that you will need to customize discovery response handling if you wish to use the non-standard `revocation_endpoint` attribute of the discovery response as the URL to be used by `Client`.

I'm also unsure about error handling. In `oauth2-rs` if the revocation URL has not been set or is not HTTPS this was implemented such that it causes a `TokenRequestError`. However, I see that `fn user_info()` handles a similar case in a different way by returning a `NoUserInfoEndpoint` error.

I also didn't update the main docs to reflect the addition of token introspection and revocation support, as I did in the `oauth2-rs` crate.

I also realize that I haven't run or updatd the tests or attempted to build with anything except default features. I have however successfully used this modified version of the create with my own application.