### PR TITLE
fix: disable openid scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -935,7 +935,7 @@ where
     /// Disables the `openid` scope from being requested automatically.
     ///
     pub fn disable_openid_scope(mut self) -> Self {
-        self.use_openid_scope = true;
+        self.use_openid_scope = false;
         self
     }
 


### PR DESCRIPTION
Hi,
The 'disable_openid_scope' function are actually enabling the property.