### PR TITLE
Add optional feature to accept RFC 3339 timestamps, for compatibility with Auth0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ curl = ["oauth2/curl"]
 reqwest = ["oauth2/reqwest"]
 native-tls = ["oauth2/native-tls"]
 rustls-tls = ["oauth2/rustls-tls"]
+accept-rfc3339-timestamps = []
 nightly = []
 
 [dependencies]

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -8,8 +8,8 @@ use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 
 use crate::helpers::FlattenFilter;
-use crate::types::helpers::{seconds_to_utc, split_language_tag_key, utc_to_seconds};
-use crate::types::{LocalizedClaim, Seconds};
+use crate::types::helpers::{split_language_tag_key, timestamp_to_utc, utc_to_seconds};
+use crate::types::{LocalizedClaim, Timestamp};
 use crate::{
     AddressCountry, AddressLocality, AddressPostalCode, AddressRegion, EndUserBirthday,
     EndUserEmail, EndUserFamilyName, EndUserGivenName, EndUserMiddleName, EndUserName,

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -839,6 +839,24 @@ mod tests {
         assert_eq!(serialized_new_claims, claims_json);
     }
 
+    // See https://github.com/ramosbugs/openidconnect-rs/issues/23
+    #[test]
+    #[cfg(feature = "accept-rfc3339-timestamps")]
+    fn test_accept_rfc3339_timestamp() {
+        let claims: CoreIdTokenClaims = serde_json::from_str(
+            "{
+            \"iss\": \"https://server.example.com\",
+            \"sub\": \"24400320\",
+            \"aud\": \"s6BhdRkqt3\",
+            \"exp\": 1311281970,
+            \"iat\": 1311280970,
+            \"updated_at\": \"2021-12-22T02:10:37.000Z\"
+            }",
+        )
+        .expect("failed to deserialize");
+        assert_eq!(claims.updated_at(), Some(Utc.timestamp(1640139037, 0)));
+    }
+
     #[test]
     fn test_unknown_claims_serde() {
         let expected_serialized_claims = "{\

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -438,16 +438,16 @@ macro_rules! deserialize_fields {
                 )
             );
         }
-        let seconds = $map.next_value::<Option<Seconds>>()?;
+        let seconds = $map.next_value::<Option<Timestamp>>()?;
         $field = seconds
-            .map(|sec| seconds_to_utc(&sec).map_err(|_| serde::de::Error::custom(
+            .map(|sec| timestamp_to_utc(&sec).map_err(|_| serde::de::Error::custom(
                 format!(
                     concat!(
                         "failed to parse `{}` as UTC datetime (in seconds) for key `",
                         stringify!($field),
                         "`"
                     ),
-                    *sec,
+                    sec,
                 )
             ))).transpose()?;
     };

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -942,9 +942,9 @@ mod tests {
     };
     use crate::jwt::tests::{TEST_RSA_PRIV_KEY, TEST_RSA_PUB_KEY};
     use crate::jwt::{JsonWebToken, JsonWebTokenJsonPayloadSerde};
-    use crate::types::helpers::seconds_to_utc;
+    use crate::types::helpers::timestamp_to_utc;
     use crate::types::Base64UrlEncodedBytes;
-    use crate::types::Seconds;
+    use crate::types::Timestamp;
     use crate::{
         AccessToken, Audience, AuthenticationContextClass, AuthorizationCode, EndUserName,
         IssuerUrl, JsonWebKeyId, Nonce, StandardClaims, UserInfoError,
@@ -1530,7 +1530,7 @@ mod tests {
                 CoreJsonWebKeySet::new(vec![rsa_key.clone()]),
             )
             .set_time_fn(|| {
-                seconds_to_utc(&Seconds::new(
+                timestamp_to_utc(&Timestamp::Seconds(
                     mock_current_time.load(Ordering::Relaxed).into(),
                 ))
                 .unwrap()
@@ -1698,7 +1698,7 @@ mod tests {
                 .set_auth_time_verifier_fn(|auth_time| {
                     assert_eq!(
                         auth_time.unwrap(),
-                        seconds_to_utc(&Seconds::new(1544928548.into())).unwrap(),
+                        timestamp_to_utc(&Timestamp::Seconds(1544928548.into())).unwrap(),
                     );
                     Err("Invalid auth_time claim".to_string())
                 })
@@ -1745,7 +1745,7 @@ mod tests {
                 CoreJsonWebKeySet::new(vec![rsa_key.clone()]),
             )
             .set_time_fn(|| {
-                seconds_to_utc(&Seconds::new(
+                timestamp_to_utc(&Timestamp::Seconds(
                     mock_current_time.load(Ordering::Relaxed).into(),
                 ))
                 .unwrap()
@@ -1779,7 +1779,7 @@ mod tests {
                 )
                 .allow_any_alg()
                 .set_time_fn(|| {
-                    seconds_to_utc(&Seconds::new(
+                    timestamp_to_utc(&Timestamp::Seconds(
                         mock_current_time.load(Ordering::Relaxed).into(),
                     ))
                     .unwrap()
@@ -1850,7 +1850,7 @@ mod tests {
             CoreJsonWebKeySet::new(vec![rsa_pub_key]),
         )
         .set_time_fn(|| {
-            seconds_to_utc(&Seconds::new(
+            timestamp_to_utc(&Timestamp::Seconds(
                 mock_current_time.load(Ordering::Relaxed).into(),
             ))
             .unwrap()


### PR DESCRIPTION
Fixes #23 