### PR TITLE
Add alternate RustCrypto backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,14 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["reqwest", "rustls-tls"]
+default = ["reqwest", "rustls-tls", "ring"]
 curl = ["oauth2/curl"]
 reqwest = ["oauth2/reqwest"]
 native-tls = ["oauth2/native-tls"]
 rustls-tls = ["oauth2/rustls-tls"]
 accept-rfc3339-timestamps = []
 nightly = []
+rustcrypto = ["rsa", "sha2", "hmac", "p256", "p384", "subtle", "dyn-clone"]
 
 [dependencies]
 base64 = "0.13"
@@ -33,7 +34,15 @@ itertools = "0.9"
 log = "0.4"
 oauth2 = { version = "4.1", default-features = false }
 rand = "0.8"
-ring = "0.16"
+ring = { version = "0.16", optional = true }
+# Using an old version as there are conflicts in the digest traits with p256 (even with 0.10)
+hmac = { version = "0.11", optional = true }
+rsa = { version = "0.5", features = ["alloc"], optional = true }
+sha2 = { version = "0.9", default-features = false, optional = true }
+p256 = { version = "0.9", optional = true }
+p384 = { version = "0.9", optional = true }
+subtle = { version = "2.4.1", optional = true }
+dyn-clone = { version = "1.0", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -886,20 +886,56 @@ impl JwsSigningAlgorithm<CoreJsonWebKeyType> for CoreJwsSigningAlgorithm {
     }
 
     fn hash_bytes(&self, bytes: &[u8]) -> Result<Vec<u8>, String> {
+        #[cfg(feature = "ring")]
         use ring::digest::{digest, SHA256, SHA384, SHA512};
+        #[cfg(feature = "rustcrypto")]
+        use sha2::{Digest, Sha256, Sha384, Sha512};
         Ok(match *self {
             CoreJwsSigningAlgorithm::HmacSha256
             | CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256
             | CoreJwsSigningAlgorithm::RsaSsaPssSha256
-            | CoreJwsSigningAlgorithm::EcdsaP256Sha256 => digest(&SHA256, bytes).as_ref().to_vec(),
+            | CoreJwsSigningAlgorithm::EcdsaP256Sha256 => {
+                #[cfg(feature = "ring")]
+                {
+                    digest(&SHA256, bytes).as_ref().to_vec()
+                }
+                #[cfg(feature = "rustcrypto")]
+                {
+                    let mut hasher = Sha256::new();
+                    hasher.update(bytes);
+                    hasher.finalize().to_vec()
+                }
+            }
             CoreJwsSigningAlgorithm::HmacSha384
             | CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha384
             | CoreJwsSigningAlgorithm::RsaSsaPssSha384
-            | CoreJwsSigningAlgorithm::EcdsaP384Sha384 => digest(&SHA384, bytes).as_ref().to_vec(),
+            | CoreJwsSigningAlgorithm::EcdsaP384Sha384 => {
+                #[cfg(feature = "ring")]
+                {
+                    digest(&SHA384, bytes).as_ref().to_vec()
+                }
+                #[cfg(feature = "rustcrypto")]
+                {
+                    let mut hasher = Sha384::new();
+                    hasher.update(bytes);
+                    hasher.finalize().to_vec()
+                }
+            }
             CoreJwsSigningAlgorithm::HmacSha512
             | CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha512
             | CoreJwsSigningAlgorithm::RsaSsaPssSha512
-            | CoreJwsSigningAlgorithm::EcdsaP521Sha512 => digest(&SHA512, bytes).as_ref().to_vec(),
+            | CoreJwsSigningAlgorithm::EcdsaP521Sha512 => {
+                #[cfg(feature = "ring")]
+                {
+                    digest(&SHA512, bytes).as_ref().to_vec()
+                }
+                #[cfg(feature = "rustcrypto")]
+                {
+                    let mut hasher = Sha512::new();
+                    hasher.update(bytes);
+                    hasher.finalize().to_vec()
+                }
+            }
             CoreJwsSigningAlgorithm::None => {
                 return Err(
                     "signature algorithm `none` has no corresponding hash algorithm".to_string(),

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -544,7 +544,7 @@ pub mod tests {
          At4JySm4v+5P7yYBh8B8YD2l9j57z/s8hJAxEbn/q8uHP2ddQqvQKgtsni+pHSk9\n\
          XGBfAoGBANz4qr10DdM8DHhPrAb2YItvPVz/VwkBd1Vqj8zCpyIEKe/07oKOvjWQ\n\
          SgkLDH9x2hBgY01SbP43CvPk0V72invu2TGkI/FXwXWJLLG7tDSgw4YyfhrYrHmg\n\
-         1Vre3XB9HH8MYBVB6UIexaAq4xSeoemRKTBesZro7OKjKT8/GmiO\
+         1Vre3XB9HH8MYBVB6UIexaAq4xSeoemRKTBesZro7OKjKT8/GmiO\n\
          -----END RSA PRIVATE KEY-----";
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,6 @@ use http::method::Method;
 use http::status::StatusCode;
 use oauth2::helpers::deserialize_space_delimited_vec;
 use rand::{thread_rng, Rng};
-use ring::constant_time;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::Error;
@@ -919,8 +918,23 @@ new_secret_type![
 ];
 impl PartialEq for Nonce {
     fn eq(&self, other: &Self) -> bool {
-        constant_time::verify_slices_are_equal(self.secret().as_bytes(), other.secret().as_bytes())
+        #[cfg(feature = "ring")]
+        {
+            ring::constant_time::verify_slices_are_equal(
+                self.secret().as_bytes(),
+                other.secret().as_bytes(),
+            )
             .is_ok()
+        }
+        #[cfg(feature = "rustcrypto")]
+        {
+            use subtle::ConstantTimeEq;
+            self.secret()
+                .as_bytes()
+                .ct_eq(other.secret().as_bytes())
+                .unwrap_u8()
+                == 1
+        }
     }
 }
 

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use oauth2::helpers::variant_name;
 use oauth2::{ClientId, ClientSecret};
-use ring::constant_time::verify_slices_are_equal;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::Error;
@@ -480,9 +479,7 @@ pub trait NonceVerifier {
 impl NonceVerifier for &Nonce {
     fn verify(self, nonce: Option<&Nonce>) -> Result<(), String> {
         if let Some(claims_nonce) = nonce {
-            if verify_slices_are_equal(claims_nonce.secret().as_bytes(), self.secret().as_bytes())
-                .is_err()
-            {
+            if claims_nonce.secret().as_bytes() != self.secret().as_bytes() {
                 return Err("nonce mismatch".to_string());
             }
         } else {


### PR DESCRIPTION
Hiya,

I have been working on deploying an IdP on Cloudflare Workers (`wasm32-unknown-unknown` target) and it is not well supported by `ring`. So I have started working on adding support for another "crypto backend" with the RustCrypto crates. And so far, it seems to work just fine. And only a few PSS padding tests are failing.

So I am opening this draft PR to see if you would be interested in the first place, and if you have any opinion or piece of advice on how to proceed. Apologies for the current state of the code, the APIs are fairly different and I wanted to limit the amount of refactoring for this first pass.

Thanks for making this crate, it's been tremendously helpful!