### PR TITLE
Add insecure_unverified_claims method

### DIFF
--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -126,11 +126,6 @@ where
         verifier.verified_claims(&self.0, nonce_verifier)
     }
 
-    /// Returns a reference to the token's claims **without performing any verification of the token's signature.**
-    pub fn insecure_unverified_claims<'a>(&'a self) -> &'a IdTokenClaims<AC, GC> {
-        self.0.unverified_payload_ref()
-    }
-
     ///
     /// Verifies and returns the ID token claims.
     ///

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -126,6 +126,11 @@ where
         verifier.verified_claims(&self.0, nonce_verifier)
     }
 
+    /// Returns a reference to the token's claims **without performing any verification of the token's signature.**
+    pub fn insecure_unverified_claims<'a>(&'a self) -> &'a IdTokenClaims<AC, GC> {
+        self.0.unverified_payload_ref()
+    }
+
     ///
     /// Verifies and returns the ID token claims.
     ///


### PR DESCRIPTION
Adds a method to read out the claims of a token without key verification.
Our use case is that there may be multiple whitelisted identity providers configured for our application, and rather than fetching the metadata for each one then attempting verification with each JWK set, we'd like to read out the issuer from the token and see if any of our whitelisted IDPs match. 

I think it's reasonable to provide an insecure escape hatch for situations like this, but I'd be open to any alternative solutions you might have!