### PR TITLE
Fix `ClientRegistrationResponse` failing to deserialize optional fiel…

### DIFF
--- a/src/registration.rs
+++ b/src/registration.rs
@@ -698,12 +698,14 @@ where
     registration_client_uri: Option<ClientConfigUrl>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        with = "serde_utc_seconds_opt"
+        with = "serde_utc_seconds_opt",
+        default
     )]
     client_id_issued_at: Option<DateTime<Utc>>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        with = "serde_utc_seconds_opt"
+        with = "serde_utc_seconds_opt",
+        default
     )]
     client_secret_expires_at: Option<DateTime<Utc>>,
     #[serde(bound = "AC: AdditionalClientMetadata", flatten)]


### PR DESCRIPTION
This PR fixes the following two issues:

## Fix `ClientRegistrationResponse` failing to deserialize optional fields `client_id_issued_at` and `client_secret_expires_at`.

> By default, serde accepts a missing field if the type of the field is Option<_>. If you add a with or deserialize_with attribute serde will fail with the "missing field" error message, as you noticed. This is on purpose. You can change what happens on missing fields with the default attribute, either applied to the field in question or the whole struct. 

Reference: https://github.com/serde-rs/serde/issues/1951

## Made `XXXUrl`'s equal behavior consistent with `url::Url`.

The following two Urls are now equal.

```rust
assert_eq!(
    IssueUrl::new("http://example.com").unwrap(),
    IssueUrl::new("http://example.com/").unwrap(),
);
```

https://github.com/ramosbugs/openidconnect-rs/blob/d5cf0ae0c80893f060157225b77284710d481291/src/discovery.rs#L404
