### PR TITLE
fix: don't depend on C code when compiling for wasm

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,6 @@ use http::method::Method;
 use http::status::StatusCode;
 use oauth2::helpers::deserialize_space_delimited_vec;
 use rand::{thread_rng, Rng};
-use ring::constant_time;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::Error;
@@ -917,10 +916,19 @@ new_secret_type![
         }
     }
 ];
+
+#[cfg(not(target_arch = "wasm32"))]
 impl PartialEq for Nonce {
     fn eq(&self, other: &Self) -> bool {
-        constant_time::verify_slices_are_equal(self.secret().as_bytes(), other.secret().as_bytes())
+        ring::constant_time::verify_slices_are_equal(self.secret().as_bytes(), other.secret().as_bytes())
             .is_ok()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl PartialEq for Nonce {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
     }
 }
 


### PR DESCRIPTION
The ring functionality used to check if the nonce is equal makes uses
of a memcpy function imported from the C world. However, this function
isn't available when compiling for wasm32.

This change uses a simple compare for wasm32, and keeps the current
behavior for all other targets.

closes issue #60