### PR TITLE
Replace chrono with time 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,6 @@ nightly = []
 
 [dependencies]
 base64 = "0.13"
-# Disable 'time' dependency since it triggers RUSTSEC-2020-0071 and we don't need it.
-chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "std",
-] }
 thiserror = "1.0"
 http = "0.2"
 itertools = "0.10"
@@ -43,6 +38,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde_path_to_error = "0.1"
 serde-value = "0.7"
+time = { version = "0.3", features = ["parsing", "std"] }
 url = { version = "2.1", features = ["serde"] }
 num-bigint = "0.4.3"
 

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -2,10 +2,10 @@ use std::fmt::{Debug, Formatter, Result as FormatterResult};
 use std::marker::PhantomData;
 use std::str;
 
-use chrono::{DateTime, Utc};
 use serde::de::{Deserialize, DeserializeOwned, Deserializer, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
+use time::OffsetDateTime;
 
 use crate::helpers::FlattenFilter;
 use crate::types::helpers::{split_language_tag_key, timestamp_to_utc, utc_to_seconds};
@@ -110,7 +110,7 @@ where
     pub(crate) phone_number: Option<EndUserPhoneNumber>,
     pub(crate) phone_number_verified: Option<bool>,
     pub(crate) address: Option<AddressClaim>,
-    pub(crate) updated_at: Option<DateTime<Utc>>,
+    pub(crate) updated_at: Option<OffsetDateTime>,
 }
 impl<GC> StandardClaims<GC>
 where
@@ -183,7 +183,7 @@ where
             set_phone_number -> phone_number[Option<EndUserPhoneNumber>],
             set_phone_number_verified -> phone_number_verified[Option<bool>],
             set_address -> address[Option<AddressClaim>],
-            set_updated_at -> updated_at[Option<DateTime<Utc>>],
+            set_updated_at -> updated_at[Option<OffsetDateTime>],
         }
     ];
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,8 @@
 //! ### Example
 //!
 //! ```rust,no_run
-//! use chrono::{Duration, Utc};
+//! use std::time::Duration;
+//! use time::OffsetDateTime;
 //! use openidconnect::{
 //!     AccessToken,
 //!     Audience,
@@ -397,9 +398,9 @@
 //!         vec![Audience::new("client-id-123".to_string())],
 //!         // The ID token expiration is usually much shorter than that of the access or refresh
 //!         // tokens issued to clients.
-//!         Utc::now() + Duration::seconds(300),
+//!         OffsetDateTime::now_utc() + Duration::from_secs(300),
 //!         // The issue time is usually the current time.
-//!         Utc::now(),
+//!         OffsetDateTime::now_utc(),
 //!         // Set the standard claims defined by the OpenID Connect Core spec.
 //!         StandardClaims::new(
 //!             // Stable subject identifiers are recommended in place of e-mail addresses or other

--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -2,12 +2,12 @@ use std::future::Future;
 use std::ops::Deref;
 use std::str;
 
-use chrono::{DateTime, Utc};
 use http::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
 use http::method::Method;
 use http::status::StatusCode;
 use oauth2::AccessToken;
 use thiserror::Error;
+use time::OffsetDateTime;
 use url::Url;
 
 use crate::helpers::FilteredFlatten;
@@ -296,7 +296,7 @@ where
             set_phone_number -> phone_number[Option<EndUserPhoneNumber>],
             set_phone_number_verified -> phone_number_verified[Option<bool>],
             set_address -> address[Option<AddressClaim>],
-            set_updated_at -> updated_at[Option<DateTime<Utc>>],
+            set_updated_at -> updated_at[Option<OffsetDateTime>],
         }
     ];
 


### PR DESCRIPTION
While the crate itself is not affected by RUSTSEC-2020-0159, crates depending on openidconnect still get flagged by `cargo audit` because the issue is still not fixed properly in chrono. Thus switch to time 0.3 which is not affected by either RUSTSEC-2020-0159 nor RUSTSEC-2020-0071.