### PR TITLE
Fix typos and markdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![Build Status](https://github.com/ramosbugs/openidconnect-rs/actions/workflows/main.yml/badge.svg)](https://github.com/ramosbugs/openidconnect-rs/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/ramosbugs/openidconnect-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/ramosbugs/openidconnect-rs)
 
-
-This library provides extensible, strongly-typed interfaces for the OpenID Connect protocol.
+This library provides extensible, strongly-typed interfaces for the OpenID
+Connect protocol.
 
 API documentation and examples are available on [docs.rs](https://docs.rs/openidconnect).
 
-# Standards
+## Standards
 
 * [OpenID Connect Core](https://openid.net/specs/openid-connect-core-1_0.html)
   * This crate passes the
@@ -41,7 +41,7 @@ API documentation and examples are available on [docs.rs](https://docs.rs/openid
 * [OAuth 2.0 Token Introspection](https://tools.ietf.org/html/rfc7662)
 * [OAuth 2.0 Token Revocation](https://tools.ietf.org/html/rfc7009)
 
-# Sponsorship
+## Sponsorship
 
-This project is sponsored by [Unflakable](https://unflakable.com), a service for tracking and
-quarantining flaky tests.
+This project is sponsored by [Unflakable](https://unflakable.com), a service
+for tracking and quarantining flaky tests.

--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -98,7 +98,7 @@ pub fn verify_rsa_signature(
     let (n, e) = rsa_public_key(key).map_err(SignatureVerificationError::InvalidKey)?;
     // let's n and e as a big integers to prevent issues with leading zeros
     // according to https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.1.1
-    // `n` is alwasy unsigned (hence has sign plus)
+    // `n` is always unsigned (hence has sign plus)
 
     let n_bigint = BigInt::from_bytes_be(Sign::Plus, n.deref());
     let e_bigint = BigInt::from_bytes_be(Sign::Plus, e.deref());

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -356,7 +356,7 @@ impl CoreRsaPrivateSigningKey {
     }
 
     /// Filters characters from the base64 input string.
-    /// Charcters are specified according to lax base64 parsing.
+    /// Characters are specified according to lax base64 parsing.
     ///
     /// RFC 7468 Lax Parsing
     fn lax_base64_parsing(input: &str) -> String {

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -485,10 +485,10 @@ mod tests {
             SubjectIdentifier::new("24400320".to_string())
         );
 
-        // test `ToString` implemenation
+        // test `ToString` implementation
         assert_eq!(&id_token.to_string(), ID_TOKEN);
 
-        // test `serde::Serialize` implemenation too
+        // test `serde::Serialize` implementation too
         let de = serde_json::to_string(&id_token).expect("failed to deserializee id token");
         assert_eq!(de, format!("\"{}\"", ID_TOKEN));
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -375,7 +375,7 @@ pub trait ResponseMode: Debug + DeserializeOwned + Serialize + 'static {}
 pub trait ResponseType: AsRef<str> + Debug + DeserializeOwned + Serialize + 'static {
     ///
     /// Converts this OpenID Connect response type to an [`oauth2::ResponseType`] used by the
-    /// underyling [`oauth2`] crate.
+    /// underlying [`oauth2`] crate.
     ///
     fn to_oauth2(&self) -> oauth2::ResponseType;
 }


### PR DESCRIPTION
See a detailed description of the rules is available at
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md