### PR TITLE
introduce `StringOrBool` to workaround illegal implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ ureq = ["oauth2/ureq"]
 native-tls = ["oauth2/native-tls"]
 rustls-tls = ["oauth2/rustls-tls"]
 accept-rfc3339-timestamps = []
+accept-string-booleans = []
 nightly = []
 
 [dependencies]

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -9,7 +9,7 @@ use serde::{Serialize, Serializer};
 
 use crate::helpers::FlattenFilter;
 use crate::types::helpers::{split_language_tag_key, timestamp_to_utc, utc_to_seconds};
-use crate::types::{LocalizedClaim, Timestamp};
+use crate::types::{Boolean, LocalizedClaim, Timestamp};
 use crate::{
     AddressCountry, AddressLocality, AddressPostalCode, AddressRegion, EndUserBirthday,
     EndUserEmail, EndUserFamilyName, EndUserGivenName, EndUserMiddleName, EndUserName,
@@ -258,13 +258,13 @@ where
                         [LanguageTag(picture)]
                         [LanguageTag(website)]
                         [Option(email)]
-                        [Option(email_verified)]
+                        [Option(Boolean(email_verified))]
                         [Option(gender)]
                         [Option(birthday)]
                         [Option(zoneinfo)]
                         [Option(locale)]
                         [Option(phone_number)]
-                        [Option(phone_number_verified)]
+                        [Option(Boolean(phone_number_verified))]
                         [Option(address)]
                         [Option(DateTime(Seconds(updated_at)))]
                     }


### PR DESCRIPTION
This is a kludge I'm using to work with Apple OAuth. They send string bools for these fields, sadly.

It's not really a merge-worthy fix, but if you can suggest a more appropriate way of integrating this (I'm sure it's a large use-case for your consumers of this library), I'm happy to throw it together.