### PR TITLE
Compare equality by URL rather than by string

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -390,7 +390,7 @@ macro_rules! new_url_type {
         }
         impl PartialEq for $name {
             fn eq(&self, other: &$name) -> bool {
-                self.1 == other.1
+                self.0 == other.0
             }
         }
         impl Eq for $name {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1399,6 +1399,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn issuer_url_equality() {
+        let issuer_url_1 = IssuerUrl::new("http://example.com".to_string()).unwrap();
+        // Note the deliberate trailing slash in the following URL
+        let issuer_url_2 = IssuerUrl::new("http://example.com/".to_string()).unwrap();
+        assert_eq!(issuer_url_1, issuer_url_2);
+    }
+
     #[cfg(feature = "accept-string-booleans")]
     #[test]
     fn test_string_bool_parse() {


### PR DESCRIPTION
There exist distinct strings that will parse to equivalent URLs. For example:

```rust
use url::Url;

fn main() {
    let x: Url = "http://example.com".parse().unwrap();
    let y: Url = "http://example.com/".parse().unwrap();
    assert_eq!(x, y); // passes
}
```

Currently, `IssuerUrl` (and every other URL type) compares for equality via the string it was parsed from, rather than the URL that it was parsed into. However, this is problematic in at least one context: when discovering provider metadata, the discovered URL is validated against the URL that was passed in. The check in question is here: https://github.com/ramosbugs/openidconnect-rs/blob/2f79ac2ec699eff2f17a2b5c50290782623d8a9f/src/discovery.rs#L404 . In this case, we have no control over the response from the server, so it's a bit frustrating when the call fails for the simple reason of including/omitting a trailing slash. It also risks accidental breakage if a server makes a harmless-seeming change to include or omit the trailing slash, for whatever reason.

(To be clear, this failure mode was much *worse* prior to https://github.com/ramosbugs/openidconnect-rs/commit/87cf0d79e4b4732e43e034f5104e99b039d1f671 .)

---

If you're wary of this approach, I can propose two alternatives:

1. If you're worried about two IssuerUrls comparing equal while containing different strings, then when the IssuerUrl is constructed here: https://github.com/ramosbugs/openidconnect-rs/blob/2f79ac2ec699eff2f17a2b5c50290782623d8a9f/src/macros.rs#L317 we could canonicalize the stored String by converting the parsed URL back into a string and storing that, rather than storing the input directly.
2. Alternatively, if you want the IssuerUrl behavior to remain the same, then this could also be fixed by changing the ProviderMetadata validation (linked above) to explicitly compare via the stored URL, rather than comparing via the equality of the IssuerUrl itself.