### PR TITLE
Pin tarpaulin to 0.21.0 on Rust 1.64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,13 +86,13 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:develop-nightly
+      image: xd009642/tarpaulin:0.21.0
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v2
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --all-features --timeout 120 --out Xml
+          cargo tarpaulin --verbose --all-features --timeout 120 --out Xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
This should help ensure consistent coverage measurements from run to run.