### PR TITLE
Core JWK use type to ignore  unknown use types

### DIFF
--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -497,6 +497,11 @@ pub enum CoreJsonWebKeyUse {
     ///
     #[serde(rename = "enc")]
     Encryption,
+    ///
+    /// Key has some other use we don't know how to make use of.
+    ///
+    #[serde(other)]
+    Unknown,
 }
 impl JsonWebKeyUse for CoreJsonWebKeyUse {
     fn allows_signature(&self) -> bool {


### PR DESCRIPTION
This is to comply with RFC 7517, Section 4: "Additional members can be present in the JWK; if not understood by implementations encountering them, they MUST be ignored"

Some providers have keys with uses that don't apply to our use case, this change enables us to ignore them gracefully.

This should fix #91 for the simple case.