### PR TITLE
Added Send to CoreRsaPrivateSigningKey.rng

### DIFF
--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -323,7 +323,7 @@ const RSA_FOOTER: &str = "-----END RSA PRIVATE KEY-----";
 ///
 pub struct CoreRsaPrivateSigningKey {
     key_pair: ring_signature::RsaKeyPair,
-    rng: Box<dyn rand::SecureRandom>,
+    rng: Box<dyn rand::SecureRandom + Send>,
     kid: Option<JsonWebKeyId>,
 }
 impl CoreRsaPrivateSigningKey {
@@ -336,7 +336,7 @@ impl CoreRsaPrivateSigningKey {
 
     pub(crate) fn from_pem_internal(
         pem: &str,
-        rng: Box<dyn rand::SecureRandom>,
+        rng: Box<dyn rand::SecureRandom + Send>,
         kid: Option<JsonWebKeyId>,
     ) -> Result<Self, String> {
         let trimmed_pem = pem.trim();


### PR DESCRIPTION
Hello! How are you?

It looks like the type that holds RSA keys from the `openidconnectcrate` (`CoreRsaPrivateSigningKey`) is not `Send` because it holds a reference to a `ring::rand:SecureRandom + 'static`. This seems a bit odd to me in real use cases (e.g. backends with multiple threads), since it doesn’t look like a key should be something `!Send`.

One question I ask to myself is why can’t I share a single key among several worker threads signing tokens? Do you have any concern with this that I am not being aware of? 

**Important Note**
This PR does not break any public API, that's why I am pull requesting it directly.

I would like to hear your thoughts on this and how we can improve the solution together.

Thank you!