### PR TITLE
feat: Abstract crypto backends

### DIFF
--- a/src/core/crypto/mod.rs
+++ b/src/core/crypto/mod.rs
@@ -1,0 +1,28 @@
+use crate::SigningError;
+use ::ring::rand::SecureRandom;
+use ::ring::signature as ring_signature;
+
+mod ring;
+
+/// Cryptography backend
+pub trait Backend {
+    fn sign_rsa(
+        key: &ring_signature::RsaKeyPair,
+        padding_alg: &'static dyn ring_signature::RsaEncoding,
+        rng: &dyn SecureRandom,
+        msg: &[u8],
+    ) -> Result<Vec<u8>, SigningError>;
+}
+
+pub struct Ring;
+
+impl Backend for Ring {
+    fn sign_rsa(
+        key: &ring_signature::RsaKeyPair,
+        padding_alg: &'static dyn ring_signature::RsaEncoding,
+        rng: &dyn SecureRandom,
+        msg: &[u8],
+    ) -> Result<Vec<u8>, SigningError> {
+        ring::sign_rsa(key, padding_alg, rng, msg)
+    }
+}

--- a/src/core/crypto/ring.rs
+++ b/src/core/crypto/ring.rs
@@ -6,7 +6,7 @@ use ring::signature as ring_signature;
 use crate::types::Base64UrlEncodedBytes;
 use crate::{JsonWebKey, SignatureVerificationError, SigningError};
 
-use super::{jwk::CoreJsonCurveType, CoreJsonWebKey, CoreJsonWebKeyType};
+use super::super::{jwk::CoreJsonCurveType, CoreJsonWebKey, CoreJsonWebKeyType};
 
 use std::ops::Deref;
 


### PR DESCRIPTION
This is a draft/preview/idea on how to abstract the crypto backend.

This wouldn't rely on any `feature` flags, but would allow the user to choose. Which might make sense for a library.

The follows the idea of e.g.: https://github.com/sfackler/rust-postgres/blob/71668b7f460955750bcfa23ffb3efb022915a6d0/postgres/src/lib.rs#L9

With the difference that you need to specify only a type, not an instance. And that there is a default type.

I am not 100% this idea works out, but I wanted to have some feedback before continuing the work.