### PR TITLE
add a Sync for CoreRsaPrivateSigningKey::rng

### DIFF
--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -323,7 +323,7 @@ const RSA_FOOTER: &str = "-----END RSA PRIVATE KEY-----";
 ///
 pub struct CoreRsaPrivateSigningKey {
     key_pair: ring_signature::RsaKeyPair,
-    rng: Box<dyn rand::SecureRandom + Send>,
+    rng: Box<dyn rand::SecureRandom + Send+Sync>,
     kid: Option<JsonWebKeyId>,
 }
 impl CoreRsaPrivateSigningKey {
@@ -336,7 +336,7 @@ impl CoreRsaPrivateSigningKey {
 
     pub(crate) fn from_pem_internal(
         pem: &str,
-        rng: Box<dyn rand::SecureRandom + Send>,
+        rng: Box<dyn rand::SecureRandom + Send+Sync>,
         kid: Option<JsonWebKeyId>,
     ) -> Result<Self, String> {
         let trimmed_pem = pem.trim();


### PR DESCRIPTION
I'm writing an openid provider with axum, need CoreRsaPrivateSigningKey's instance be sharable,but CoreRsaPrivateSigningKey::rng is `!Sync`, I only give a `Sync` marker for this field,then my code can go pass.

```rust
lazy_static::lazy_static! {
    pub static ref RSA_KEY:Arc<CoreRsaPrivateSigningKey> = get_rsa_key();
}
fn get_rsa_key() -> Arc<CoreRsaPrivateSigningKey> {
    let pem = std::env::var("JWK_RSA_PRI_PEM").expect("can't read the JWK_RSA_PRI_PEM env var");
    let rsa_pem_file = File::open(pem).expect("can't open the JWK_RSA_PRI_PEM file");
    let mut rsa_pem_reader = std::io::BufReader::new(rsa_pem_file);
    let mut rsa_pem = String::new();
    rsa_pem_reader
        .read_to_string(&mut rsa_pem)
        .expect("can't read the JWK_RSA_PRI_PEM file");

    let rsa_sign_key =
        CoreRsaPrivateSigningKey::from_pem(&rsa_pem, Some(JsonWebKeyId::new("key1".to_string())))
            .expect("can't parse the JWK_RSA_PRI_PEM file");
    Arc::new(rsa_sign_key)
}
``` 