### PR TITLE
fix: don't enforce jwk signing algorithm if empty

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -800,7 +800,7 @@ where
     issuer: IssuerUrl,
     userinfo_endpoint: Option<UserInfoUrl>,
     jwks: JsonWebKeySet<JS, JT, JU, K>,
-    id_token_signing_algs: Vec<JS>,
+    id_token_signing_algs: Option<Vec<JS>>,
     use_openid_scope: bool,
     _phantom: PhantomData<(AC, AD, GC, JE, P)>,
 }
@@ -825,8 +825,9 @@ where
 {
     ///
     /// Initializes an OpenID Connect client.
-    /// If you need to configure the algorithms used for signing, ...,
-    /// do this directly on the respected components. (e.g. IdTokenVerifier)
+    /// WARNING: does not restrict id token signing algorithms,
+    /// either set_allowed_algs on the IdTokenVerifier or 
+    /// use from_provider_metadata instead
     ///
     pub fn new(
         client_id: ClientId,
@@ -849,7 +850,7 @@ where
             issuer,
             userinfo_endpoint,
             jwks,
-            id_token_signing_algs: vec![],
+            id_token_signing_algs: None,
             use_openid_scope: true,
             _phantom: PhantomData,
         }
@@ -889,9 +890,11 @@ where
             issuer: provider_metadata.issuer().clone(),
             userinfo_endpoint: provider_metadata.userinfo_endpoint().cloned(),
             jwks: provider_metadata.jwks().to_owned(),
-            id_token_signing_algs: provider_metadata
-                .id_token_signing_alg_values_supported()
-                .to_owned(),
+            id_token_signing_algs: Some(
+                provider_metadata
+                    .id_token_signing_alg_values_supported()
+                    .to_owned(),
+            ),
             use_openid_scope: true,
             _phantom: PhantomData,
         }
@@ -977,7 +980,11 @@ where
             )
         };
 
-        verifier.set_allowed_algs(self.id_token_signing_algs.clone())
+        if let Some(id_token_signing_algs) = self.id_token_signing_algs.clone() {
+            verifier.set_allowed_algs(id_token_signing_algs)
+        } else {
+            verifier
+        }
     }
 
     ///


### PR DESCRIPTION
Makes the CoreClient::new function usable for claim verification again, as it was in 2.4, while still enforcing IF we have enough context to do so, improving usability of the library.

When attempting to verify a claim using CoreClient::new (as done in 2.4) in version 2.5, the error `Signature verification failed\\n\\nCaused by:\\n    Disallowed signature algorithm: algorithm `RS256` is not one of: \"` is returned (due to Client::new setting an empty array for supported algorithms).

## Context:
OIDC provider: auth0 or google
version: 2.5