### PR TITLE
Remove unnecessary 'static bound from `ProviderMetadata::discover_async`

### DIFF
--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -323,7 +323,7 @@ where
     ) -> Result<Self, DiscoveryError<RE>>
     where
         F: Future<Output = Result<HttpResponse, RE>>,
-        HC: Fn(HttpRequest) -> F + 'static,
+        HC: Fn(HttpRequest) -> F,
         RE: std::error::Error + 'static,
     {
         let discovery_url = issuer_url


### PR DESCRIPTION
Allows for `http_client` to be a closure which captures values by non-static reference.