### PR TITLE
Implements the device authorisation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ new major version number for this crate.
 * [OpenID Connect RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
 * [OAuth 2.0 Token Introspection](https://tools.ietf.org/html/rfc7662)
 * [OAuth 2.0 Token Revocation](https://tools.ietf.org/html/rfc7009)
+* [OAuth 2.0 Device Authorization Grant](https://www.rfc-editor.org/rfc/rfc8628)
 
 ## Sponsorship
 

--- a/examples/okta_device_grant.rs
+++ b/examples/okta_device_grant.rs
@@ -1,0 +1,135 @@
+//!
+//! This example showcases the process of using the device grant flow to obtain an ID token from the
+//! [Okta](https://developer.okta.com/docs/guides/device-authorization-grant/main/#request-the-device-verification-code)
+//! provider.
+//!
+//! Before running it, you'll need to generate your own
+//! [Okta Server](https://developer.okta.com/signup/).
+//!
+//! In order to run the example call:
+//!
+//! ```sh
+//! CLIENT_ID=xxx CLIENT_SECRET=yyy ISSUER_URL=zzz cargo run --example okta_device_grant
+//! ```
+//!
+//! ...and follow the instructions.
+//!
+
+use openidconnect::core::{
+    CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClient, CoreClientAuthMethod,
+    CoreDeviceAuthorizationResponse, CoreDeviceAuthorizationUrl, CoreGrantType, CoreJsonWebKey,
+    CoreJsonWebKeyType, CoreJsonWebKeyUse, CoreJweContentEncryptionAlgorithm,
+    CoreJweKeyManagementAlgorithm, CoreJwsSigningAlgorithm, CoreResponseMode, CoreResponseType,
+    CoreSubjectIdentifierType,
+};
+use openidconnect::{
+    AdditionalProviderMetadata, AuthType, ClientId, ClientSecret, IssuerUrl, ProviderMetadata,
+    Scope,
+};
+use std::env;
+
+use serde::{Deserialize, Serialize};
+
+use openidconnect::reqwest::http_client;
+
+use std::process::exit;
+
+// Obtain the device_authorization_url from the OIDC metadata provider.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct DeviceEndpointProviderMetadata {
+    device_authorization_endpoint: CoreDeviceAuthorizationUrl,
+}
+impl AdditionalProviderMetadata for DeviceEndpointProviderMetadata {}
+type DeviceProviderMetadata = ProviderMetadata<
+    DeviceEndpointProviderMetadata,
+    CoreAuthDisplay,
+    CoreClientAuthMethod,
+    CoreClaimName,
+    CoreClaimType,
+    CoreGrantType,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJweKeyManagementAlgorithm,
+    CoreJwsSigningAlgorithm,
+    CoreJsonWebKeyType,
+    CoreJsonWebKeyUse,
+    CoreJsonWebKey,
+    CoreResponseMode,
+    CoreResponseType,
+    CoreSubjectIdentifierType,
+>;
+
+fn handle_error<T: std::error::Error>(fail: &T, msg: &'static str) {
+    let mut err_msg = format!("ERROR: {}", msg);
+    let mut cur_fail: Option<&dyn std::error::Error> = Some(fail);
+    while let Some(cause) = cur_fail {
+        err_msg += &format!("\n    caused by: {}", cause);
+        cur_fail = cause.source();
+    }
+    println!("{}", err_msg);
+    exit(1);
+}
+
+fn main() -> Result<(), anyhow::Error> {
+    env_logger::init();
+
+    let client_id =
+        ClientId::new(env::var("CLIENT_ID").expect("Missing the CLIENT_ID environment variable."));
+    let client_secret = ClientSecret::new(
+        env::var("CLIENT_SECRET").expect("Missing the CLIENT_SECRET environment variable."),
+    );
+    let issuer_url = IssuerUrl::new(
+        env::var("ISSUER_URL")
+            .expect("Missing the ISSUER_URL environment variable.")
+            .to_string(),
+    )
+    .expect("Invalid issuer URL");
+
+    // Fetch Okta's OpenID Connect discovery document.
+    let provider_metadata = DeviceProviderMetadata::discover(&issuer_url, http_client)
+        .unwrap_or_else(|err| {
+            handle_error(&err, "Failed to discover OpenID Provider");
+            unreachable!();
+        });
+
+    // Use the custom metadata to get the device_authorization_endpoint
+    let device_authorization_endpoint = provider_metadata
+        .additional_metadata()
+        .device_authorization_endpoint
+        .clone();
+
+    // Set up the config for the Okta devuce authorization process.
+    let client =
+        CoreClient::from_provider_metadata(provider_metadata, client_id, Some(client_secret))
+            .set_device_authorization_uri(device_authorization_endpoint)
+            .set_auth_type(AuthType::RequestBody);
+
+    let details: CoreDeviceAuthorizationResponse = client
+        .exchange_device_code()?
+        .add_scope(Scope::new("profile".to_string()))
+        .request(http_client)
+        .expect("Failed to get device code");
+    println!("Fetching device code...");
+    dbg!(&details);
+
+    // Display the URL and user-code.
+    println!(
+        "Open this URL in your browser:\n{}\nand enter the code: {}",
+        details
+            .verification_uri_complete()
+            .unwrap()
+            .secret()
+            .to_string(),
+        details.user_code().secret().to_string()
+    );
+
+    // Now poll for the token
+    let token = client
+        .exchange_device_token(&details)
+        .request(http_client, std::thread::sleep, None)
+        .expect("Failed to get token");
+
+    // Finally, display the ID Token to verify we are using OIDC
+    println!("ID Token response: {:?}", token.extra_fields().id_token());
+
+    Ok(())
+}

--- a/examples/okta_device_grant.rs
+++ b/examples/okta_device_grant.rs
@@ -17,14 +17,13 @@
 
 use openidconnect::core::{
     CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClient, CoreClientAuthMethod,
-    CoreDeviceAuthorizationResponse, CoreDeviceAuthorizationUrl, CoreGrantType, CoreJsonWebKey,
-    CoreJsonWebKeyType, CoreJsonWebKeyUse, CoreJweContentEncryptionAlgorithm,
-    CoreJweKeyManagementAlgorithm, CoreJwsSigningAlgorithm, CoreResponseMode, CoreResponseType,
-    CoreSubjectIdentifierType,
+    CoreDeviceAuthorizationResponse, CoreGrantType, CoreJsonWebKey, CoreJsonWebKeyType,
+    CoreJsonWebKeyUse, CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm,
+    CoreJwsSigningAlgorithm, CoreResponseMode, CoreResponseType, CoreSubjectIdentifierType,
 };
 use openidconnect::{
-    AdditionalProviderMetadata, AuthType, ClientId, ClientSecret, IssuerUrl, ProviderMetadata,
-    Scope,
+    AdditionalProviderMetadata, AuthType, ClientId, ClientSecret, DeviceAuthorizationUrl,
+    IssuerUrl, ProviderMetadata, Scope,
 };
 use std::env;
 
@@ -37,7 +36,7 @@ use std::process::exit;
 // Obtain the device_authorization_url from the OIDC metadata provider.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct DeviceEndpointProviderMetadata {
-    device_authorization_endpoint: CoreDeviceAuthorizationUrl,
+    device_authorization_endpoint: DeviceAuthorizationUrl,
 }
 impl AdditionalProviderMetadata for DeviceEndpointProviderMetadata {}
 type DeviceProviderMetadata = ProviderMetadata<
@@ -97,7 +96,7 @@ fn main() -> Result<(), anyhow::Error> {
         .device_authorization_endpoint
         .clone();
 
-    // Set up the config for the Okta devuce authorization process.
+    // Set up the config for the Okta device authorization process.
     let client =
         CoreClient::from_provider_metadata(provider_metadata, client_id, Some(client_secret))
             .set_device_authorization_uri(device_authorization_endpoint)
@@ -114,17 +113,13 @@ fn main() -> Result<(), anyhow::Error> {
     // Display the URL and user-code.
     println!(
         "Open this URL in your browser:\n{}\nand enter the code: {}",
-        details
-            .verification_uri_complete()
-            .unwrap()
-            .secret()
-            .to_string(),
-        details.user_code().secret().to_string()
+        details.verification_uri_complete().unwrap().secret(),
+        details.user_code().secret()
     );
 
     // Now poll for the token
     let token = client
-        .exchange_device_token(&details)
+        .exchange_device_access_token(&details)
         .request(http_client, std::thread::sleep, None)
         .expect("Failed to get token");
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,8 +8,6 @@ pub use oauth2::basic::{
 };
 
 use oauth2::devicecode::{DeviceAuthorizationResponse, EmptyExtraDeviceAuthorizationFields};
-pub use oauth2::DeviceAuthorizationUrl as CoreDeviceAuthorizationUrl;
-
 pub use oauth2::StandardRevocableToken as CoreRevocableToken;
 use oauth2::{
     EmptyExtraTokenFields, ErrorResponseType, ResponseType as OAuth2ResponseType,
@@ -43,7 +41,7 @@ mod crypto;
 mod jwk;
 
 ///
-/// OpenID Connect Core device authorization response.
+/// Standard implementation of DeviceAuthorizationResponse which throws away extra received response fields.
 ///
 pub type CoreDeviceAuthorizationResponse =
     DeviceAuthorizationResponse<EmptyExtraDeviceAuthorizationFields>;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,10 @@ pub use oauth2::basic::{
     BasicRequestTokenError as CoreRequestTokenError,
     BasicRevocationErrorResponse as CoreRevocationErrorResponse, BasicTokenType as CoreTokenType,
 };
+
+use oauth2::devicecode::{DeviceAuthorizationResponse, EmptyExtraDeviceAuthorizationFields};
+pub use oauth2::DeviceAuthorizationUrl as CoreDeviceAuthorizationUrl;
+
 pub use oauth2::StandardRevocableToken as CoreRevocableToken;
 use oauth2::{
     EmptyExtraTokenFields, ErrorResponseType, ResponseType as OAuth2ResponseType,
@@ -37,6 +41,12 @@ mod crypto;
 
 // Private purely for organizational reasons; exported publicly above.
 mod jwk;
+
+///
+/// OpenID Connect Core device authorization response.
+///
+pub type CoreDeviceAuthorizationResponse =
+    DeviceAuthorizationResponse<EmptyExtraDeviceAuthorizationFields>;
 
 ///
 /// OpenID Connect Core token introspection response.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,9 +576,12 @@ extern crate pretty_assertions;
 #[macro_use]
 extern crate serde_derive;
 
-pub use oauth2::devicecode::{DeviceAuthorizationResponse, EmptyExtraDeviceAuthorizationFields};
+pub use oauth2::devicecode::{
+    DeviceAuthorizationResponse, DeviceCodeErrorResponse, DeviceCodeErrorResponseType,
+    EmptyExtraDeviceAuthorizationFields, ExtraDeviceAuthorizationFields,
+};
 use oauth2::ResponseType as OAuth2ResponseType;
-pub use oauth2::{DeviceAccessTokenRequest, DeviceAuthorizationRequest};
+pub use oauth2::{DeviceAccessTokenRequest, DeviceAuthorizationRequest, DeviceCode};
 use url::Url;
 
 use std::borrow::Cow;
@@ -1078,9 +1081,9 @@ where
     }
 
     ///
-    /// Creates a request builder for exchanging a device code for an access token.
+    /// Creates a request builder for device authorization.
     ///
-    /// See https://tools.ietf.org/html/rfc8628#section-3.4
+    /// See <https://tools.ietf.org/html/rfc8628#section-3.4>
     ///
     pub fn exchange_device_code(
         &self,
@@ -1095,19 +1098,16 @@ where
 
     ///
     /// Creates a request builder for exchanging a device code for an access token.
-    /// This method is similar to [`exchange_device_code`][Client::exchange_device_code] but
-    /// allows the caller to specify additional parameters to be sent to the authorization server.
-    /// This is useful for providers that require additional parameters to be sent in the request
-    /// body.
     ///
-    /// See https://tools.ietf.org/html/rfc8628#section-3.4
+    /// See <https://tools.ietf.org/html/rfc8628#section-3.4>
     ///
-    pub fn exchange_device_token<'a, 'b, 'c>(
+    pub fn exchange_device_access_token<'a, 'b, 'c, EF>(
         &'a self,
-        auth_response: &'b DeviceAuthorizationResponse<EmptyExtraDeviceAuthorizationFields>,
-    ) -> DeviceAccessTokenRequest<'b, 'c, TR, TT, EmptyExtraDeviceAuthorizationFields>
+        auth_response: &'b DeviceAuthorizationResponse<EF>,
+    ) -> DeviceAccessTokenRequest<'b, 'c, TR, TT, EF>
     where
         'a: 'b,
+        EF: ExtraDeviceAuthorizationFields,
     {
         self.oauth2_client
             .exchange_device_access_token(auth_response)


### PR DESCRIPTION
* Adds support for OAuth 2.0 Device Authorization Grant
* Updates `core/mod.rs` to include the new `CoreDeviceAuthorizationResponse` type
* Updates `lib.rs` to provide access to `DeviceAuthorizationUrl` and `DeviceAuthorizationRequest` types
* Adds `set_device_authorization_uri` method to the `Client` API to set the URL for contacting the device authorization endpoint
* Implements an example that showcases the process of using the device grant flow to obtain an ID token from the Okta provider. The example demonstrates device code exchange for an access token.

Solves #113