### PR TITLE
Implement `From<Url>` for `new_url_type`s

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -332,6 +332,11 @@ macro_rules! new_url_type {
                 &self.1
             }
         }
+        impl From<Url> for $name {
+            fn from(value: Url) -> Self {
+                Self::from_url(value)
+            }
+        }
         impl ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
                 let mut debug_trait_builder = f.debug_tuple(stringify!($name));


### PR DESCRIPTION
I thought it would be nice to implement `From<Url>` for the url-like types. If there's a reason you believe this shouldn't be done (I note the existence of a `from_url` function) please feel free to close.