### PR TITLE
Add wasm support

### DIFF
--- a/Cargo-1.65.lock
+++ b/Cargo-1.65.lock
@@ -149,9 +149,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ base64 = "0.13"
 chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "std",
+    "wasmbind"
 ] }
 thiserror = "1.0"
 http = "0.2"


### PR DESCRIPTION
Chrono's wasm support wasn't enabled, probably because the [docs](https://docs.rs/chrono/0.4.29/chrono/index.html) were outdated and it is currently not listed in the crate's default features but is present in the [README](https://github.com/chronotope/chrono/blob/0.4.x/README.md) .

https://github.com/chronotope/chrono/pull/1260 updates the docs on their side. I can also make a PR for oauth2-rs if you want.