### PR TITLE
add EdDSA alg support

### DIFF
--- a/Cargo-1.65.lock
+++ b/Cargo-1.65.lock
@@ -208,9 +208,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -284,6 +284,34 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -415,6 +443,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +532,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
 name = "flate2"
@@ -1064,6 +1121,7 @@ dependencies = [
  "chrono",
  "color-backtrace",
  "dyn-clone",
+ "ed25519-dalek",
  "env_logger",
  "hmac",
  "http",
@@ -1230,6 +1288,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "platforms"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
 name = "ppv-lite86"
@@ -1446,6 +1510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1607,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ serde_with = "3"
 serde-value = "0.7"
 url = { version = "2.4", features = ["serde"] }
 subtle = "2.4"
-ed25519-dalek = "2.0.0"
+ed25519-dalek = { version = "2.0.0", features = ["pem"] }
 
 [dev-dependencies]
 color-backtrace = { version = "0.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ serde_with = "3"
 serde-value = "0.7"
 url = { version = "2.4", features = ["serde"] }
 subtle = "2.4"
+ed25519-dalek = "2.0.0"
 
 [dev-dependencies]
 color-backtrace = { version = "0.5" }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and will not happen in patch releases.
     * Relying Party flows: code, implicit, hybrid
     * Standard claims
     * UserInfo endpoint
-    * RSA, HMAC, and ECDSA (P-256/P-384 curves) ID token verification
+    * RSA, HMAC, ECDSA (P-256/P-384 curves) and EdDSA (Ed25519 curve) ID token verification
   * Unsupported features:
     * Aggregated and distributed claims
     * Passing request parameters as JWTs

--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -61,11 +61,11 @@ fn ed_public_key(
         let x = key
             .x
             .as_ref()
-            .ok_or_else(|| "ED `x` part is missing".to_string())?;
+            .ok_or_else(|| "OKP `x` part is missing".to_string())?;
         let crv = key
             .crv
             .as_ref()
-            .ok_or_else(|| "EC `crv` part is missing".to_string())?;
+            .ok_or_else(|| "OKP `crv` part is missing".to_string())?;
         Ok((x, crv))
     }
 }

--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -54,13 +54,7 @@ fn ec_public_key(
 
 fn ed_public_key(
     key: &CoreJsonWebKey,
-) -> Result<
-    (
-        &Base64UrlEncodedBytes,
-        &CoreJsonCurveType,
-    ),
-    String,
-> {
+) -> Result<(&Base64UrlEncodedBytes, &CoreJsonCurveType), String> {
     if *key.key_type() != CoreJsonWebKeyType::OctetKeyPair {
         Err("OKP key required".to_string())
     } else {
@@ -146,14 +140,16 @@ pub fn verify_ec_signature(
         CoreJsonCurveType::P521 => Err(SignatureVerificationError::UnsupportedAlg(
             "P521".to_string(),
         )),
-        _ => Err(SignatureVerificationError::InvalidKey(format!("unrecognized curve `{crv:?}`")))
+        _ => Err(SignatureVerificationError::InvalidKey(format!(
+            "unrecognized curve `{crv:?}`"
+        ))),
     }
 }
 
 pub fn verify_ed_signature(
     key: &CoreJsonWebKey,
     msg: &[u8],
-    signature: &[u8]
+    signature: &[u8],
 ) -> Result<(), SignatureVerificationError> {
     use ed25519_dalek::Verifier;
 
@@ -169,13 +165,15 @@ pub fn verify_ed_signature(
                     msg,
                     &ed25519_dalek::Signature::from_slice(signature).map_err(|_| {
                         SignatureVerificationError::CryptoError("invalid signature".to_string())
-                    })?
+                    })?,
                 )
                 .map_err(|_| {
                     SignatureVerificationError::CryptoError("incorrect EdDSA signature".to_string())
                 })
         }
-        _ => Err(SignatureVerificationError::InvalidKey(format!("unrecognized curve `{crv:?}`")))
+        _ => Err(SignatureVerificationError::InvalidKey(format!(
+            "unrecognized curve `{crv:?}`"
+        ))),
     }
 }
 

--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -62,7 +62,7 @@ fn ed_public_key(
     String,
 > {
     if *key.key_type() != CoreJsonWebKeyType::OctetKeyPair {
-        Err("ED key required".to_string())
+        Err("OKP key required".to_string())
     } else {
         let x = key
             .x
@@ -146,7 +146,7 @@ pub fn verify_ec_signature(
         CoreJsonCurveType::P521 => Err(SignatureVerificationError::UnsupportedAlg(
             "P521".to_string(),
         )),
-        _ => Err(SignatureVerificationError::InvalidKey("Invalid key".to_string()))
+        _ => Err(SignatureVerificationError::InvalidKey(format!("unrecognized curve `{crv:?}`")))
     }
 }
 
@@ -168,14 +168,14 @@ pub fn verify_ed_signature(
                 .verify(
                     msg,
                     &ed25519_dalek::Signature::from_slice(signature).map_err(|_| {
-                        SignatureVerificationError::CryptoError("Invalid signature".to_string())
+                        SignatureVerificationError::CryptoError("invalid signature".to_string())
                     })?
                 )
                 .map_err(|_| {
-                    SignatureVerificationError::CryptoError("ED Signature was wrong".to_string())
+                    SignatureVerificationError::CryptoError("incorrect EdDSA signature".to_string())
                 })
         }
-        _ => Err(SignatureVerificationError::InvalidKey("Invalid key".to_string()))
+        _ => Err(SignatureVerificationError::InvalidKey(format!("unrecognized curve `{crv:?}`")))
     }
 }
 

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -165,6 +165,8 @@ impl CoreJsonWebKey {
             x: Some(Base64UrlEncodedBytes::new(x)),
             y: None,
             d: None,
+            #[cfg(feature = "jwk-alg")]
+            alg: None,
         }
     }
 }
@@ -541,6 +543,8 @@ impl
                 y: None,
                 d: None,
                 k: None,
+                #[cfg(feature = "jwk-alg")]
+                alg: None,
             },
         }
     }
@@ -1087,6 +1091,26 @@ mod tests {
             pkcs1_signing_input,
             signature_ed25519_other,
         );
+
+        // non-EdDsa key
+        if let Some(err) = key_ed25519
+            .verify_signature(
+                &CoreJwsSigningAlgorithm::EcdsaP256Sha256,
+                pkcs1_signing_input.as_bytes(),
+                signature_ed25519.as_bytes(),
+            )
+            .err()
+        {
+            let error_msg = "key type does not match signature algorithm".to_string();
+            match err {
+                SignatureVerificationError::InvalidKey(msg) => {
+                    if msg != error_msg {
+                        panic!("The error should be about key type")
+                    }
+                }
+                _ => panic!("We should fail before actual validation"),
+            }
+        }
     }
 
     #[test]

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -437,7 +437,13 @@ impl
     }
 }
 
+///
+/// Variants of EdDSA Key.
+///
 pub enum EdDsaVariant {
+    ///
+    /// Ed25519 Variant
+    /// 
     Ed25519,
 }
 

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -128,7 +128,7 @@ impl CoreJsonWebKey {
         }
     }
 
-    /// Instantiate a new ED public key from the raw x (`x`) part of the curve,
+    /// Instantiate a new Octet Key-Pair public key from the raw x (`x`) part of the curve,
     /// along with an optional (but recommended) key ID.
     ///
     /// The key ID is used for matching signed JSON Web Tokens with the keys used for verifying

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -125,6 +125,30 @@ impl CoreJsonWebKey {
             d: None,
         }
     }
+
+    /// Instantiate a new ED public key from the raw x (`x`) part of the curve,
+    /// along with an optional (but recommended) key ID.
+    ///
+    /// The key ID is used for matching signed JSON Web Tokens with the keys used for verifying
+    /// their signatures.
+    pub fn new_okp(
+        x: Vec<u8>,
+        crv: CoreJsonCurveType,
+        kid: Option<JsonWebKeyId>
+    ) -> Self {
+        Self {
+            kty: CoreJsonWebKeyType::OctetKeyPair,
+            use_: Some(CoreJsonWebKeyUse::Signature),
+            kid,
+            n: None,
+            e: None,
+            k: None,
+            crv: Some(crv),
+            x: Some(Base64UrlEncodedBytes::new(x)),
+            y: None,
+            d: None,
+        }
+    }
 }
 impl JsonWebKey<CoreJwsSigningAlgorithm, CoreJsonWebKeyType, CoreJsonWebKeyUse> for CoreJsonWebKey {
     fn key_id(&self) -> Option<&JsonWebKeyId> {

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -1065,22 +1065,20 @@ mod tests {
         );
 
         // signature from ed448 variant
-        key_ed25519
-            .verify_signature(
-                &CoreJwsSigningAlgorithm::EdDsaEd25519,
-                pkcs1_signing_input.as_bytes(),
-                &base64::decode_config(signature_ed448, crate::core::base64_url_safe_no_pad()).unwrap().as_slice()
-            )
-            .expect_err("verification should fail");
+        verify_invalid_signature(
+            &key_ed25519,
+            &CoreJwsSigningAlgorithm::EdDsaEd25519,
+            pkcs1_signing_input,
+            signature_ed448
+        );
 
         // different signature
-        key_ed25519
-            .verify_signature(
-                &CoreJwsSigningAlgorithm::EdDsaEd25519,
-                pkcs1_signing_input.as_bytes(),
-                &base64::decode_config(signature_ed25519_other, crate::core::base64_url_safe_no_pad()).unwrap().as_slice()
-            )
-            .expect_err("verification should fail");
+        verify_invalid_signature(
+            &key_ed25519,
+            &CoreJwsSigningAlgorithm::EdDsaEd25519,
+            pkcs1_signing_input,
+            signature_ed25519_other
+        );
     }
 
     #[test]

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -482,11 +482,20 @@ impl EdDsaSigningKey {
     }
 }
 
+///
+/// EdDSA Private Key.
+///
+/// This key can be used for signing messages, or converted to a `CoreJsonWebKey` for verifying
+/// them.
+///
 pub struct CoreEdDsaPrivateSigningKey {
     kid: Option<JsonWebKeyId>,
     key_pair: EdDsaSigningKey,
 }
 impl CoreEdDsaPrivateSigningKey {
+    ///
+    /// Converts an EdDSA private key (in PEM format) to a JWK representing its public key.
+    ///
     pub fn from_pem(pem: &str, kid: Option<JsonWebKeyId>, variant: EdDsaVariant) -> Result<Self, String> {
         match variant {
             EdDsaVariant::Ed25519 => Ok(Self {

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -914,12 +914,34 @@ mod tests {
         let pkcs1_signing_input = "eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJpc3MiOiJqb2UifQ";
         let signature_ed25519 = "Augr7UH6hUbWVN0PHqSD5U0bb8y9UOw_eef09ZS5d5haUar_qAto8gyLJxUhNF5wHPoXhdvSGowkPvjiKsEsCQ";
 
+        let signature_ed25519_other = "xb4NH-q33sCaRXf1ZhnzQxd4o5ZkBWKd9vGibacqPMAblW_mIJLm9kGerqHX08SPoeDY-dYUmZQz9ls6csfvAw";
+        let signature_ed448 = "xxXVMyaYYePdGfMOdU0nENuc70pKwP3vJuc_jBA0rCW-RtbvBLSsc0D9iCPzhrPmQ2X1nTjPkGiAXJ0_NslDBvy3sHu88N64YhnnYBWwwHttBU0jijn_ikbBUHzUwzGuasRFb1ESG_PwedhEcMi-YAwA";
+
+        // test ed25519
         verify_signature(
             &key_ed25519,
             &CoreJwsSigningAlgorithm::EdDsaEd25519,
             pkcs1_signing_input,
             signature_ed25519
         );
+
+        // signature from ed448 variant
+        key_ed25519
+            .verify_signature(
+                &CoreJwsSigningAlgorithm::EdDsaEd25519,
+                pkcs1_signing_input.as_bytes(),
+                &base64::decode_config(signature_ed448, crate::core::base64_url_safe_no_pad()).unwrap().as_slice()
+            )
+            .expect_err("verification should fail");
+
+        // different signature
+        key_ed25519
+            .verify_signature(
+                &CoreJwsSigningAlgorithm::EdDsaEd25519,
+                pkcs1_signing_input.as_bytes(),
+                &base64::decode_config(signature_ed25519_other, crate::core::base64_url_safe_no_pad()).unwrap().as_slice()
+            )
+            .expect_err("verification should fail");
     }
 
     #[test]

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -774,6 +774,30 @@ mod tests {
     }
 
     #[test]
+    fn test_core_jwk_deserialization_ed() {
+        let json =  "{
+            \"alg\": \"Ed25519\",
+            \"crv\": \"Ed25519\",
+            \"kty\": \"OKP\",
+            \"use\": \"sig\",
+            \"x\": \"vZ3CX884r0qNJ18pgXUTvFufK3ZmDzQfvMROJz6CLBc\"
+        }";
+
+        let key: CoreJsonWebKey = serde_json::from_str(json).expect("deserialization failed");
+        assert_eq!(key.kty, CoreJsonWebKeyType::OctetKeyPair);
+        assert_eq!(key.use_, Some(CoreJsonWebKeyUse::Signature));
+        assert_eq!(key.crv, Some(CoreJsonCurveType::Ed25519));
+        assert_eq!(
+            key.x,
+            Some(Base64UrlEncodedBytes::new(vec![
+                0xBD, 0x9D, 0xC2, 0x5F, 0xCF, 0x38, 0xAF, 0x4A, 0x8D, 0x27, 0x5F, 0x29, 0x81, 0x75,
+                0x13, 0xBC, 0x5B, 0x9F, 0x2B, 0x76, 0x66, 0x0F, 0x34, 0x1F, 0xBC, 0xC4, 0x4E, 0x27,
+                0x3E, 0x82, 0x2C, 0x17
+            ]))
+        );
+    }
+
+    #[test]
     fn test_core_jwk_deserialization_symmetric() {
         let json = "{\
             \"kty\":\"oct\",

--- a/src/core/jwk.rs
+++ b/src/core/jwk.rs
@@ -440,7 +440,7 @@ impl
 ///
 /// Variants of EdDSA Key.
 ///
-pub enum EdDsaVariant {
+pub enum CoreEdDsaKeyVariant {
     ///
     /// Ed25519 Variant
     /// 
@@ -448,14 +448,14 @@ pub enum EdDsaVariant {
 }
 
 struct EdDsaSigningKey {
-    variant: EdDsaVariant,
+    variant: CoreEdDsaKeyVariant,
     ed25519: Option<ed25519_dalek::SigningKey>,
 }
 
 impl EdDsaSigningKey {
-    fn from_pem(pem: &str, variant: EdDsaVariant) -> Result<Self, String> {
+    fn from_pem(pem: &str, variant: CoreEdDsaKeyVariant) -> Result<Self, String> {
         match variant {
-            EdDsaVariant::Ed25519 => Ok(Self {
+            CoreEdDsaKeyVariant::Ed25519 => Ok(Self {
                 variant,
                 ed25519: Some(ed25519_dalek::SigningKey::from_pkcs8_pem(pem).map_err(|err| err.to_string())?),
             })
@@ -464,7 +464,7 @@ impl EdDsaSigningKey {
 
     fn public_part(&self) -> Vec<u8> {
         match self.variant {
-            EdDsaVariant::Ed25519 => {
+            CoreEdDsaKeyVariant::Ed25519 => {
                 self.ed25519
                     .as_ref()
                     .expect("fail to refer to Ed25519 signing key")
@@ -477,7 +477,7 @@ impl EdDsaSigningKey {
 
     fn sign(&self, message: &[u8]) -> Vec<u8> {
         match self.variant {
-            EdDsaVariant::Ed25519 => {
+            CoreEdDsaKeyVariant::Ed25519 => {
                 let key = self.ed25519.as_ref().expect("fail to refer to Ed25519 signing key");
 
                 let signature = key.sign(message);
@@ -502,9 +502,9 @@ impl CoreEdDsaPrivateSigningKey {
     ///
     /// Converts an EdDSA private key (in PEM format) to a JWK representing its public key.
     ///
-    pub fn from_pem(pem: &str, kid: Option<JsonWebKeyId>, variant: EdDsaVariant) -> Result<Self, String> {
+    pub fn from_pem(pem: &str, kid: Option<JsonWebKeyId>, variant: CoreEdDsaKeyVariant) -> Result<Self, String> {
         match variant {
-            EdDsaVariant::Ed25519 => Ok(Self {
+            CoreEdDsaKeyVariant::Ed25519 => Ok(Self {
                 kid,
                 key_pair: EdDsaSigningKey::from_pem(pem, variant)?,
             })
@@ -834,7 +834,7 @@ mod tests {
 
     use super::{
         CoreHmacKey, CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse,
-        CoreJwsSigningAlgorithm, CoreRsaPrivateSigningKey, PrivateSigningKey, CoreEdDsaPrivateSigningKey, EdDsaVariant,
+        CoreJwsSigningAlgorithm, CoreRsaPrivateSigningKey, PrivateSigningKey, CoreEdDsaPrivateSigningKey, CoreEdDsaKeyVariant,
     };
     use super::{CoreJsonCurveType, SigningError};
 
@@ -1529,7 +1529,7 @@ mod tests {
         let private_key = CoreEdDsaPrivateSigningKey::from_pem(
             TEST_ED25519_KEY,
             Some(JsonWebKeyId::new("test_key".to_string())),
-            EdDsaVariant::Ed25519,
+            CoreEdDsaKeyVariant::Ed25519,
         )
         .unwrap();
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,7 +33,7 @@ use super::AuthenticationFlow;
 
 pub use self::jwk::{
     CoreHmacKey, CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse, CoreRsaPrivateSigningKey,
-    CoreEdDsaKeyVariant, CoreEdDsaPrivateSigningKey
+    CoreEdDsaPrivateSigningKey
 };
 
 mod crypto;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -855,6 +855,11 @@ pub enum CoreJwsSigningAlgorithm {
     #[serde(rename = "PS512")]
     RsaSsaPssSha512,
     ///
+    /// EdDSA signature using Ed25519 curve 
+    ///
+    #[serde(rename = "Ed25519")]
+    EdDsaEd25519,
+    ///
     /// No digital signature or MAC performed.
     ///
     /// # Security Warning
@@ -883,6 +888,7 @@ impl JwsSigningAlgorithm<CoreJsonWebKeyType> for CoreJwsSigningAlgorithm {
             CoreJwsSigningAlgorithm::EcdsaP256Sha256
             | CoreJwsSigningAlgorithm::EcdsaP384Sha384
             | CoreJwsSigningAlgorithm::EcdsaP521Sha512 => Some(CoreJsonWebKeyType::EllipticCurve),
+            CoreJwsSigningAlgorithm::EdDsaEd25519 => Some(CoreJsonWebKeyType::OctetKeyPair),
             CoreJwsSigningAlgorithm::None => None,
         }
     }
@@ -919,6 +925,11 @@ impl JwsSigningAlgorithm<CoreJsonWebKeyType> for CoreJwsSigningAlgorithm {
                 let mut hasher = Sha512::new();
                 hasher.update(bytes);
                 hasher.finalize().to_vec()
+            }
+            CoreJwsSigningAlgorithm::EdDsaEd25519 => {
+                return Err(
+                    "signature algorithm `Ed25519` has no corresponding hash algorithm".to_string(),
+                );
             }
             CoreJwsSigningAlgorithm::None => {
                 return Err(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,6 +33,7 @@ use super::AuthenticationFlow;
 
 pub use self::jwk::{
     CoreHmacKey, CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse, CoreRsaPrivateSigningKey,
+    CoreEdDsaPrivateSigningKey
 };
 
 mod crypto;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,8 +32,8 @@ use crate::{
 use super::AuthenticationFlow;
 
 pub use self::jwk::{
-    CoreHmacKey, CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse, CoreRsaPrivateSigningKey,
-    CoreEdDsaPrivateSigningKey
+    CoreEdDsaPrivateSigningKey, CoreHmacKey, CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse,
+    CoreRsaPrivateSigningKey,
 };
 
 mod crypto;
@@ -856,7 +856,7 @@ pub enum CoreJwsSigningAlgorithm {
     #[serde(rename = "PS512")]
     RsaSsaPssSha512,
     ///
-    /// EdDSA signature using Ed25519 curve 
+    /// EdDSA signature using Ed25519 curve
     ///
     #[serde(rename = "Ed25519")]
     EdDsaEd25519,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,7 +33,7 @@ use super::AuthenticationFlow;
 
 pub use self::jwk::{
     CoreHmacKey, CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse, CoreRsaPrivateSigningKey,
-    EdDsaVariant, CoreEdDsaPrivateSigningKey
+    CoreEdDsaKeyVariant, CoreEdDsaPrivateSigningKey
 };
 
 mod crypto;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,7 +33,7 @@ use super::AuthenticationFlow;
 
 pub use self::jwk::{
     CoreHmacKey, CoreJsonWebKey, CoreJsonWebKeyType, CoreJsonWebKeyUse, CoreRsaPrivateSigningKey,
-    CoreEdDsaPrivateSigningKey
+    EdDsaVariant, CoreEdDsaPrivateSigningKey
 };
 
 mod crypto;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -928,9 +928,9 @@ impl JwsSigningAlgorithm<CoreJsonWebKeyType> for CoreJwsSigningAlgorithm {
                 hasher.finalize().to_vec()
             }
             CoreJwsSigningAlgorithm::EdDsaEd25519 => {
-                return Err(
-                    "signature algorithm `Ed25519` has no corresponding hash algorithm".to_string(),
-                );
+                let mut hasher = Sha512::new();
+                hasher.update(bytes);
+                hasher.finalize().to_vec()
             }
             CoreJwsSigningAlgorithm::None => {
                 return Err(

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -500,6 +500,14 @@ pub mod tests {
             \"e\": \"AQAB\"
         }";
 
+    pub const TEST_ED_PUB_KEY_ED25519: &str = r#"{
+        "kty": "OKP",
+        "use": "sig",
+        "alg": "Ed25519",
+        "crv": "Ed25519",
+        "x": "sfliRRhciU_d5qsuC5Vcydi-t8bRfxTg_4qulVatW4A"
+    }"#;
+
     pub const TEST_EC_PUB_KEY_P256: &str = r#"{
         "kty": "EC",
         "kid": "bilbo.baggins@hobbiton.example",


### PR DESCRIPTION
this pr contains

- [x] `eddsa` signing key option supports for `ed25519` variant
- [x] add `CoreJsonWebKey::new_okp`
- [x] add `CoreEdDsaPrivateSigningKey`
- [x] unit tests
  - [x] `test_eddsa_verification`
  - [x] `test_core_jwk_deserialization_ed`
  - [x]  `test_ed_signing` for `CoreEdDsaPrivateSigningKey`

discussion: [issue](https://github.com/ramosbugs/openidconnect-rs/issues/129)

lastly thanks everyone for all your awesome work on this library and happy to have any feedback about this pr