### PR TITLE
Take JWK alg into account during key selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ rustls-tls = ["oauth2/rustls-tls"]
 accept-rfc3339-timestamps = []
 accept-string-booleans = []
 nightly = []
+# TODO: remove this feature gate on the next major release
+# see https://github.com/ramosbugs/openidconnect-rs/pull/131#discussion_r1349786021
 jwk-alg = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rustls-tls = ["oauth2/rustls-tls"]
 accept-rfc3339-timestamps = []
 accept-string-booleans = []
 nightly = []
+jwk-alg = []
 
 [dependencies]
 base64 = "0.13"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -933,7 +933,6 @@ impl JwsSigningAlgorithm<CoreJsonWebKeyType> for CoreJwsSigningAlgorithm {
     }
 }
 
-
 ///
 /// OpenID Connect Core authentication error response types.
 ///

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -934,6 +934,29 @@ impl JwsSigningAlgorithm<CoreJsonWebKeyType> for CoreJwsSigningAlgorithm {
 }
 
 ///
+/// JWK allowed algorithm "alg" field, [Section 4.4 of RFC 7517](https://www.rfc-editor.org/rfc/rfc7517#section-4.4)
+///
+/// All JSON Web Algorithms listed in [RFC 7518](https://www.rfc-editor.org/rfc/rfc7518) can be encoded by this enum.
+///
+/// There are a few caveats, which can be deduced from [the "Algorithm Usage Location(s)" part of Section 7.1.1](https://www.rfc-editor.org/rfc/rfc7518#section-7.1.1):
+///  - According to the specification, algorithms might have multiple purposes (like both JWE and JWS).
+///    No such algorithm is currently listed, but it if were to happen, the current flattened enum approach would stop working
+///  - According to the specification, algorithms which aren't used for JWE nor JWS may be added to the list.
+///    No such algorithm is currently listed.
+/// According to the "Algorithm Usage Location(s)" section of  https://www.rfc-editor.org/rfc/rfc7518#section-7.1.1
+///
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum CoreJwkAlgorithm {
+    /// This JWK is intended for JWE key management
+    JWEKeyManagement(CoreJweKeyManagementAlgorithm),
+    /// This JWK is intended for JWE content encryption
+    JWEContentEncryption(CoreJweContentEncryptionAlgorithm),
+    /// This JWK is intended for JWS signing
+    JWS(CoreJwsSigningAlgorithm),
+}
+
+///
 /// OpenID Connect Core authentication error response types.
 ///
 /// This type represents errors returned in a redirect from the Authorization Endpoint to the
@@ -1207,7 +1230,7 @@ impl ResponseMode for CoreResponseMode {}
 /// OpenID Connect Core response type.
 ///
 /// Informs the Authorization Server of the desired authorization processing flow, including what
-/// parameters are returned from the endpoints used.  
+/// parameters are returned from the endpoints used.
 ///
 /// This type represents a single Response Type. Multiple Response Types are represented via the
 /// `ResponseTypes` type, which wraps a `Vec<ResponseType>`.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -933,28 +933,6 @@ impl JwsSigningAlgorithm<CoreJsonWebKeyType> for CoreJwsSigningAlgorithm {
     }
 }
 
-///
-/// JWK allowed algorithm "alg" field, [Section 4.4 of RFC 7517](https://www.rfc-editor.org/rfc/rfc7517#section-4.4)
-///
-/// All JSON Web Algorithms listed in [RFC 7518](https://www.rfc-editor.org/rfc/rfc7518) can be encoded by this enum.
-///
-/// There are a few caveats, which can be deduced from [the "Algorithm Usage Location(s)" part of Section 7.1.1](https://www.rfc-editor.org/rfc/rfc7518#section-7.1.1):
-///  - According to the specification, algorithms might have multiple purposes (like both JWE and JWS).
-///    No such algorithm is currently listed, but it if were to happen, the current flattened enum approach would stop working
-///  - According to the specification, algorithms which aren't used for JWE nor JWS may be added to the list.
-///    No such algorithm is currently listed.
-/// According to the "Algorithm Usage Location(s)" section of  https://www.rfc-editor.org/rfc/rfc7518#section-7.1.1
-///
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum CoreJwkAlgorithm {
-    /// This JWK is intended for JWE key management
-    JWEKeyManagement(CoreJweKeyManagementAlgorithm),
-    /// This JWK is intended for JWE content encryption
-    JWEContentEncryption(CoreJweContentEncryptionAlgorithm),
-    /// This JWK is intended for JWS signing
-    JWS(CoreJwsSigningAlgorithm),
-}
 
 ///
 /// OpenID Connect Core authentication error response types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,13 +638,14 @@ pub use types::{
     EndUserEmail, EndUserFamilyName, EndUserGivenName, EndUserMiddleName, EndUserName,
     EndUserNickname, EndUserPhoneNumber, EndUserPictureUrl, EndUserProfileUrl, EndUserTimezone,
     EndUserUsername, EndUserWebsiteUrl, FormattedAddress, GrantType, InitiateLoginUrl, IssuerUrl,
-    JsonWebKey, JsonWebKeyId, JsonWebKeySet, JsonWebKeySetUrl, JsonWebKeyType, JsonWebKeyUse,
-    JweContentEncryptionAlgorithm, JweKeyManagementAlgorithm, JwsSigningAlgorithm, LanguageTag,
-    LocalizedClaim, LoginHint, LogoUrl, LogoutHint, Nonce, OpPolicyUrl, OpTosUrl, PolicyUrl,
-    PostLogoutRedirectUrl, PrivateSigningKey, RegistrationAccessToken, RegistrationUrl, RequestUrl,
-    ResponseMode, ResponseType, ResponseTypes, SectorIdentifierUrl, ServiceDocUrl, SigningError,
-    StreetAddress, SubjectIdentifier, SubjectIdentifierType, ToSUrl,
+    JsonWebKey, JsonWebKeyAlgorithm, JsonWebKeyId, JsonWebKeySet, JsonWebKeySetUrl, JsonWebKeyType,
+    JsonWebKeyUse, JweContentEncryptionAlgorithm, JweKeyManagementAlgorithm, JwsSigningAlgorithm,
+    LanguageTag, LocalizedClaim, LoginHint, LogoUrl, LogoutHint, Nonce, OpPolicyUrl, OpTosUrl,
+    PolicyUrl, PostLogoutRedirectUrl, PrivateSigningKey, RegistrationAccessToken, RegistrationUrl,
+    RequestUrl, ResponseMode, ResponseType, ResponseTypes, SectorIdentifierUrl, ServiceDocUrl,
+    SigningError, StreetAddress, SubjectIdentifier, SubjectIdentifierType, ToSUrl,
 };
+
 pub use user_info::{
     UserInfoClaims, UserInfoError, UserInfoJsonWebToken, UserInfoRequest, UserInfoUrl,
 };

--- a/src/types.rs
+++ b/src/types.rs
@@ -234,10 +234,11 @@ where
     fn key_use(&self) -> Option<&JU>;
 
     ///
-    /// Returns the algorithm (e.g. ES512) this key must be used with, or `None` if no algorithm
-    /// constraint was specified.
+    /// Returns the algorithm (e.g. ES512) this key must be used with, or `Unspecified` if
+    /// no algorithm constraint was given, or unsupported if the algorithm is not for signing.
     ///
-    fn check_compatibility(&self, signing_algorithm: &JS) -> Result<(), &'static str>;
+    #[cfg(feature = "jwk-alg")]
+    fn signing_alg(&self) -> JsonWebKeyAlgorithm<&JS>;
 
     ///
     /// Initializes a new symmetric key or shared signing secret from the specified raw bytes.
@@ -256,6 +257,13 @@ where
         message: &[u8],
         signature: &[u8],
     ) -> Result<(), SignatureVerificationError>;
+}
+
+#[cfg(feature = "jwk-alg")]
+pub enum JsonWebKeyAlgorithm<A> {
+    Algorithm(A),
+    Unspecified,
+    Unsupported,
 }
 
 ///
@@ -743,6 +751,45 @@ where
     #[serde(skip)]
     _phantom: PhantomData<(JS, JT, JU)>,
 }
+
+///
+/// Checks whether a JWK key can be used with a given signing algorithm.
+///
+pub(crate) fn check_key_compatibility<JS, JT, JU, K>(
+    key: &K,
+    signing_algorithm: &JS,
+) -> Result<(), &'static str>
+where
+    JS: JwsSigningAlgorithm<JT>,
+    JT: JsonWebKeyType,
+    JU: JsonWebKeyUse,
+    K: JsonWebKey<JS, JT, JU>,
+{
+    // if this key isn't suitable for signing
+    if let Some(use_) = key.key_use() {
+        if !use_.allows_signature() {
+            return Err("key usage not permitted for digital signatures");
+        }
+    }
+
+    // if this key doesn't have the right key type
+    if signing_algorithm.key_type().as_ref() != Some(key.key_type()) {
+        return Err("key type does not match signature algorithm");
+    }
+
+    #[cfg(feature = "jwk-alg")]
+    match key.signing_alg() {
+        // if no specific algorithm is mandated, any will do
+        JsonWebKeyAlgorithm::Unspecified => Ok(()),
+        JsonWebKeyAlgorithm::Unsupported => Err("key algorithm is not a signing algorithm"),
+        JsonWebKeyAlgorithm::Algorithm(key_alg) if key_alg == signing_algorithm => Ok(()),
+        JsonWebKeyAlgorithm::Algorithm(_) => Err("incompatible key algorithm"),
+    }
+
+    #[cfg(not(feature = "jwk-alg"))]
+    Ok(())
+}
+
 impl<JS, JT, JU, K> JsonWebKeySet<JS, JT, JU, K>
 where
     JS: JwsSigningAlgorithm<JT>,
@@ -763,7 +810,7 @@ where
     ///
     /// Return a list of suitable keys, given a key id an signature algorithm
     ///
-    pub fn filter_keys(&self, key_id: &Option<JsonWebKeyId>, signature_alg: &JS) -> Vec<&K> {
+    pub(crate) fn filter_keys(&self, key_id: &Option<JsonWebKeyId>, signature_alg: &JS) -> Vec<&K> {
         self.keys()
         .iter()
         .filter(|key|
@@ -772,7 +819,7 @@ where
             if key_id.is_some() && key_id.as_ref() != key.key_id() {
                 false
             } else {
-                key.check_compatibility(signature_alg).is_ok()
+                check_key_compatibility(*key, signature_alg).is_ok()
             }
         )
         .collect()

--- a/src/types.rs
+++ b/src/types.rs
@@ -237,6 +237,8 @@ where
     /// Returns the algorithm (e.g. ES512) this key must be used with, or `Unspecified` if
     /// no algorithm constraint was given, or unsupported if the algorithm is not for signing.
     ///
+    /// It's not sufficient to tell whether a key can be used for signing, as key use also has to be validated.
+    ///
     #[cfg(feature = "jwk-alg")]
     fn signing_alg(&self) -> JsonWebKeyAlgorithm<&JS>;
 
@@ -259,10 +261,16 @@ where
     ) -> Result<(), SignatureVerificationError>;
 }
 
-#[cfg(feature = "jwk-alg")]
-pub enum JsonWebKeyAlgorithm<A> {
+///
+/// Encodes a JWK key's alg field compatibility with either signing or encryption operations.
+///
+#[derive(Debug)]
+pub enum JsonWebKeyAlgorithm<A: Debug> {
+    /// the alg field allows this kind of operation to be performed with this algorithm only
     Algorithm(A),
+    /// there is no alg field
     Unspecified,
+    /// the alg field's algorithm is incompatible with this kind of operation
     Unsupported,
 }
 

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -1401,6 +1401,7 @@ mod tests {
                 x: None,
                 y: None,
                 d: None,
+                #[cfg(feature = "jwk-alg")]
                 alg: None,
             }]),
         )
@@ -1427,6 +1428,7 @@ mod tests {
                 x: None,
                 y: None,
                 d: None,
+                #[cfg(feature = "jwk-alg")]
                 alg: None,
             }]),
         )


### PR DESCRIPTION
Without this change, there may be multiple compatible keys, which causes an AmbiguousKeyId error. Using the key algorithm to narrow the list down further fixes the issue.

We've seen this edge case in the wild on a specific OpenAM instance.