### PR TITLE
Add support for specific JOSE header types

### DIFF
--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -21,6 +21,7 @@ new_type![
 ];
 
 new_type![
+    /// JSON web token type field (typ)
     #[derive(Deserialize, Hash, Ord, PartialOrd, Serialize)]
     JsonWebTokenType(String)
 ];

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -20,11 +20,107 @@ new_type![
     JsonWebTokenContentType(String)
 ];
 
+/// Error type used when normalizing [`JsonWebTokenType`] objects
+#[derive(Error, Debug)]
+#[error("Invalid JWT type: {typ}")]
+pub struct InvalidJsonWebTokenTypeError {
+    typ: String,
+}
+
 new_type![
-    /// JSON web token type field (typ)
-    #[derive(Deserialize, Hash, Ord, PartialOrd, Serialize)]
+    /// JSON Web Token type field (typ)
+    ///
+    /// This type stores the raw (deserialized) value.
+    ///
+    /// To compare two different JSON Web Token types, please use the normalized version via [`JsonWebTokenType::normalize`].
+    #[derive(Deserialize, Hash, Serialize)]
     JsonWebTokenType(String)
+
+    impl {
+        /// Expands a [`JsonWebTokenType`] and produces a [`NormalizedJsonWebTokenType`] according to RFC2045 and RFC7515.
+        ///
+        /// See [RFC 2045 section 5.1](https://tools.ietf.org/html/rfc2045#section-5.1) for the full Content-Type Header Field spec.
+        /// See [RFC 7515 section 4.19](https://tools.ietf.org/html/rfc7515#section-4.1.9) for specific requirements of JSON Web Token Types.
+        pub fn normalize(&self) -> Result<NormalizedJsonWebTokenType, InvalidJsonWebTokenTypeError> {
+            self.try_into()
+        }
+    }
 ];
+
+/// Normalized JSON Web Token type field (typ)
+///
+/// This type stores the normalized value of a [`JsonWebTokenType`].
+/// To retrieve a normalized value according to RFC2045 and RFC7515 see [`JsonWebTokenType::normalize`]
+///
+/// See [RFC 2045 section 5.1](https://tools.ietf.org/html/rfc2045#section-5.1) for the full Content-Type Header Field spec.
+/// See [RFC 7515 section 4.1.9](https://tools.ietf.org/html/rfc7515#section-4.1.9) for specific requirements of JSON Web Token Types.
+///
+/// It is recommended to instantiate `NormalizedJsonWebTokenType` objects via [`JsonWebTokenType`] and then call [`JsonWebTokenType::normalize`].
+///
+/// ```rust
+/// # use openidconnect::{NormalizedJsonWebTokenType, JsonWebTokenType};
+/// let token_type = JsonWebTokenType::new("jwt+at".to_string()).normalize();
+/// // normalized value looks like "application/jwt+at"
+/// # assert_eq!(*token_type.unwrap(), "application/jwt+at")
+/// ```
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
+pub struct NormalizedJsonWebTokenType(String);
+
+impl std::ops::Deref for NormalizedJsonWebTokenType {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+impl From<NormalizedJsonWebTokenType> for String {
+    fn from(t: NormalizedJsonWebTokenType) -> String {
+        t.0
+    }
+}
+
+impl From<NormalizedJsonWebTokenType> for JsonWebTokenType {
+    fn from(t: NormalizedJsonWebTokenType) -> JsonWebTokenType {
+        JsonWebTokenType::new(t.0)
+    }
+}
+
+impl TryFrom<&JsonWebTokenType> for NormalizedJsonWebTokenType {
+    type Error = InvalidJsonWebTokenTypeError;
+
+    /// Normalizes a [`JsonWebTokenType`] and produces a [`NormalizedJsonWebTokenType`] according to RFC2045.
+    ///
+    /// See [RFC 2045 section 5.1](https://tools.ietf.org/html/rfc2045#section-5.1) for the full Content-Type Header Field spec.
+    /// See [RFC 7515 section 4.19](https://tools.ietf.org/html/rfc7515#section-4.1.9) for specific requirements of JSON Web Token Types.
+    fn try_from(t: &JsonWebTokenType) -> Result<NormalizedJsonWebTokenType, Self::Error> {
+        let lowercase_jwt_type = t.0.to_lowercase();
+        if let Some(slash_location) = lowercase_jwt_type.find('/') {
+            if let Some(semicolon_location) = lowercase_jwt_type.find(';') {
+                // If '/' is not before ';' as then the MIME type is invalid
+                // e.g. some;arg="1/2" is invalid, but application/some;arg=1 is valid
+                // OR
+                // If MIME type has not at least one character
+                // OR
+                // If MIME subtype has not at least one character
+                if slash_location > semicolon_location
+                    || slash_location == 0
+                    || slash_location.saturating_add(1) >= semicolon_location
+                {
+                    Err(InvalidJsonWebTokenTypeError {
+                        typ: lowercase_jwt_type,
+                    })
+                } else {
+                    Ok(NormalizedJsonWebTokenType(lowercase_jwt_type))
+                }
+            } else {
+                Ok(NormalizedJsonWebTokenType(lowercase_jwt_type))
+            }
+        } else {
+            Ok(NormalizedJsonWebTokenType(format!(
+                "application/{lowercase_jwt_type}"
+            )))
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,7 +705,7 @@ pub use crate::discovery::{
 };
 pub use crate::id_token::IdTokenFields;
 pub use crate::id_token::{IdToken, IdTokenClaims};
-pub use crate::jwt::JsonWebTokenError;
+pub use crate::jwt::{JsonWebTokenError, JsonWebTokenType};
 pub use crate::logout::{LogoutProviderMetadata, LogoutRequest, ProviderMetadataWithLogout};
 pub use crate::token::TokenResponse;
 // Flatten the module hierarchy involving types. They're only separated to improve code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,7 +705,7 @@ pub use crate::discovery::{
 };
 pub use crate::id_token::IdTokenFields;
 pub use crate::id_token::{IdToken, IdTokenClaims};
-pub use crate::jwt::{JsonWebTokenError, JsonWebTokenType};
+pub use crate::jwt::{JsonWebTokenError, JsonWebTokenType, NormalizedJsonWebTokenType};
 pub use crate::logout::{LogoutProviderMetadata, LogoutRequest, ProviderMetadataWithLogout};
 pub use crate::token::TokenResponse;
 // Flatten the module hierarchy involving types. They're only separated to improve code

--- a/src/verification/tests.rs
+++ b/src/verification/tests.rs
@@ -6,7 +6,9 @@ use crate::core::{
 };
 use crate::helpers::{timestamp_to_utc, Base64UrlEncodedBytes, Timestamp};
 use crate::jwt::tests::{TEST_RSA_PRIV_KEY, TEST_RSA_PUB_KEY};
-use crate::jwt::{JsonWebToken, JsonWebTokenHeader, JsonWebTokenJsonPayloadSerde};
+use crate::jwt::{
+    JsonWebToken, JsonWebTokenHeader, JsonWebTokenJsonPayloadSerde, JsonWebTokenType,
+};
 use crate::verification::{AudiencesClaim, IssuerClaim, JwtClaimsVerifier};
 use crate::{
     AccessToken, Audience, AuthenticationContextClass, AuthorizationCode, ClaimsVerificationError,
@@ -36,9 +38,60 @@ fn assert_unsupported<T>(result: Result<T, ClaimsVerificationError>, expected_su
 
 #[test]
 fn test_jose_header() {
+    let client_id = ClientId::new("my_client".to_string());
+    let issuer = IssuerUrl::new("https://example.com".to_string()).unwrap();
+    let verifier = CoreJwtClaimsVerifier::new(
+        client_id.clone(),
+        issuer.clone(),
+        CoreJsonWebKeySet::new(vec![]),
+    );
+
+    // Happy path JWT
+    verifier
+        .validate_jose_header(
+            &serde_json::from_str::<CoreJsonWebTokenHeader>("{\"alg\":\"RS256\", \"typ\":\"JWT\"}")
+                .expect("failed to deserialize"),
+        )
+        .expect("JWT type should be allowed but is not");
+
+    verifier
+        .validate_jose_header(
+            &serde_json::from_str::<CoreJsonWebTokenHeader>("{\"alg\":\"RS256\", \"typ\":\"jwt\"}")
+                .expect("failed to deserialize"),
+        )
+        .expect("JWT type should be allowed but is not");
+
+    verifier
+        .validate_jose_header(
+            &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                "{\"alg\":\"RS256\", \"typ\":\"application/JWT\"}",
+            )
+            .expect("failed to deserialize"),
+        )
+        .expect("JWT type should be allowed but is not");
+
+    // Happy path JOSE
+    verifier
+        .validate_jose_header(
+            &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                "{\"alg\":\"RS256\", \"typ\":\"jose\"}",
+            )
+            .expect("failed to deserialize"),
+        )
+        .expect("JWT type should be allowed but is not");
+
+    verifier
+        .validate_jose_header(
+            &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                "{\"alg\":\"RS256\", \"typ\":\"JOSE\"}",
+            )
+            .expect("failed to deserialize"),
+        )
+        .expect("JWT type should be allowed but is not");
+
     // Unexpected JWT type.
     assert_unsupported(
-        CoreJwtClaimsVerifier::validate_jose_header(
+        verifier.validate_jose_header(
             &serde_json::from_str::<CoreJsonWebTokenHeader>(
                 "{\"alg\":\"RS256\",\"typ\":\"NOT_A_JWT\"}",
             )
@@ -47,16 +100,121 @@ fn test_jose_header() {
         "unsupported JWT type",
     );
 
+    // No typ at all.
+    verifier
+        .validate_jose_header(
+            &serde_json::from_str::<CoreJsonWebTokenHeader>("{\"alg\":\"RS256\"}")
+                .expect("failed to deserialize"),
+        )
+        .expect("JWT type should be allowed but is not");
+
+    // Specific JWT type from list.
+    {
+        let custom_verifier = CoreJwtClaimsVerifier::new(
+            client_id.clone(),
+            issuer.clone(),
+            CoreJsonWebKeySet::new(vec![]),
+        )
+        .set_allowed_jose_types(vec![
+            JsonWebTokenType::new("application/NOT_A_JWT".to_string()),
+            JsonWebTokenType::new("APPLICATION/AT+jwt".to_string()),
+        ]);
+
+        custom_verifier
+            .validate_jose_header(
+                &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                    "{\"alg\":\"RS256\",\"typ\":\"NOT_A_JWT\"}",
+                )
+                .expect("failed to deserialize"),
+            )
+            .expect("JWT type should be allowed but is not");
+
+        custom_verifier
+            .validate_jose_header(
+                &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                    "{\"alg\":\"RS256\",\"typ\":\"application/NOT_A_JWT\"}",
+                )
+                .expect("failed to deserialize"),
+            )
+            .expect("JWT type should be allowed but is not");
+
+        assert_unsupported(
+            custom_verifier.validate_jose_header(
+                &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                    "{\"alg\":\"RS256\",\"typ\":\"application/NOT_A_JWT;bla=test\"}",
+                )
+                .expect("failed to deserialize"),
+            ),
+            "unsupported JWT type",
+        );
+
+        custom_verifier
+            .validate_jose_header(
+                &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                    "{\"alg\":\"RS256\",\"typ\":\"application/at+jwt\"}",
+                )
+                .expect("failed to deserialize"),
+            )
+            .expect("JWT type should be allowed but is not");
+
+        assert_unsupported(
+            custom_verifier.validate_jose_header(
+                &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                    "{\"alg\":\"RS256\",\"typ\":\"NOT_A_JWT_REALLY\"}",
+                )
+                .expect("failed to deserialize"),
+            ),
+            "unsupported JWT type",
+        );
+    }
+
+    // Allow all JWT types.
+    {
+        let custom_verifier = CoreJwtClaimsVerifier::new(
+            client_id.clone(),
+            issuer.clone(),
+            CoreJsonWebKeySet::new(vec![]),
+        )
+        .allow_all_jose_types();
+
+        custom_verifier
+            .validate_jose_header(
+                &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                    "{\"alg\":\"RS256\",\"typ\":\"NOT_A_JWT\"}",
+                )
+                .expect("failed to deserialize"),
+            )
+            .expect("JWT type should be allowed but is not");
+
+        custom_verifier
+            .validate_jose_header(
+                &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                    "{\"alg\":\"RS256\",\"typ\":\"application/at+jwt\"}",
+                )
+                .expect("failed to deserialize"),
+            )
+            .expect("JWT type should be allowed but is not");
+
+        custom_verifier
+            .validate_jose_header(
+                &serde_json::from_str::<CoreJsonWebTokenHeader>(
+                    "{\"alg\":\"RS256\",\"typ\":\"NOT_A_JWT_REALLY\"}",
+                )
+                .expect("failed to deserialize"),
+            )
+            .expect("JWT type should be allowed but is not");
+    }
+
     // Nested JWTs.
     assert_unsupported(
-        CoreJwtClaimsVerifier::validate_jose_header(
+        verifier.validate_jose_header(
             &serde_json::from_str::<CoreJsonWebTokenHeader>("{\"alg\":\"RS256\",\"cty\":\"JWT\"}")
                 .expect("failed to deserialize"),
         ),
         "nested JWT",
     );
     assert_unsupported(
-        CoreJwtClaimsVerifier::validate_jose_header(
+        verifier.validate_jose_header(
             &serde_json::from_str::<CoreJsonWebTokenHeader>(
                 "{\"alg\":\"RS256\",\"cty\":\"NOT_A_JWT\"}",
             )
@@ -67,7 +225,7 @@ fn test_jose_header() {
 
     // Critical fields. Adapted from https://tools.ietf.org/html/rfc7515#appendix-E
     assert_unsupported(
-        CoreJwtClaimsVerifier::validate_jose_header(
+        verifier.validate_jose_header(
             &serde_json::from_str::<CoreJsonWebTokenHeader>(
                 "{\
                      \"alg\":\"RS256\",\


### PR DESCRIPTION
Check https://www.rfc-editor.org/rfc/rfc7519#section-5.1 and https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9 for more information on when the typ header should be set and to which value.

This commit allows to skip the check altogether as warranted by RFC 7515 the use of the header is optional but if set, according to RFC 7519, it should be set to "JWT". For other token types this is different (see RFC 9068).

Resolves #160 