### PR TITLE
Include the body in DiscoveryError.Parse

### DIFF
--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -378,7 +378,7 @@ where
         let provider_metadata = serde_path_to_error::deserialize::<_, Self>(
             &mut serde_json::Deserializer::from_slice(discovery_response.body()),
         )
-        .map_err(DiscoveryError::Parse)?;
+        .map_err(|err_msg| DiscoveryError::Parse(discovery_response.body().to_owned(), err_msg))?;
 
         if provider_metadata.issuer() != issuer_url {
             Err(DiscoveryError::Validation(format!(
@@ -413,7 +413,10 @@ where
     Other(String),
     /// Failed to parse server response.
     #[error("Failed to parse server response")]
-    Parse(#[source] serde_path_to_error::Error<serde_json::Error>),
+    Parse(
+        Vec<u8>,
+        #[source] serde_path_to_error::Error<serde_json::Error>,
+    ),
     /// An error occurred while sending the request or receiving the response (e.g., network
     /// connectivity failed).
     #[error("Request failed")]

--- a/src/registration/mod.rs
+++ b/src/registration/mod.rs
@@ -654,12 +654,12 @@ where
             let response_error: StandardErrorResponse<ET> = serde_path_to_error::deserialize(
                 &mut serde_json::Deserializer::from_str(&response_body),
             )
-            .map_err(ClientRegistrationError::Parse)?;
+            .map_err(|err_msg| ClientRegistrationError::Parse(response_body.into(), err_msg))?;
             return Err(ClientRegistrationError::ServerResponse(response_error));
         }
 
         serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_str(&response_body))
-            .map_err(ClientRegistrationError::Parse)
+            .map_err(|err_msg| ClientRegistrationError::Parse(response_body.into(), err_msg))
     }
 
     /// Returns the client metadata associated with this registration request.
@@ -902,7 +902,10 @@ where
     Other(String),
     /// Failed to parse server response.
     #[error("Failed to parse server response")]
-    Parse(#[source] serde_path_to_error::Error<serde_json::Error>),
+    Parse(
+        Vec<u8>,
+        #[source] serde_path_to_error::Error<serde_json::Error>,
+    ),
     /// An error occurred while sending the request or receiving the response (e.g., network
     /// connectivity failed).
     #[error("Request failed")]

--- a/src/types/jwks.rs
+++ b/src/types/jwks.rs
@@ -164,7 +164,7 @@ where
         serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(
             http_response.body(),
         ))
-        .map_err(DiscoveryError::Parse)
+        .map_err(|err_msg| DiscoveryError::Parse(http_response.body().to_owned(), err_msg))
     }
 
     /// Return the keys in this JSON Web Key Set.


### PR DESCRIPTION
Hey,

Just wanted access to the body in case of a Parse error for the discovery endpoint.
Made a separate commit with the same modification for UserInfoError and ClientRegistrationError.