### PR TITLE
Implement `FromStr` for URL newtypes

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -346,6 +346,12 @@ macro_rules! new_url_type {
             }
             $($item)*
         }
+        impl std::str::FromStr for $name {
+            type Err = ::url::ParseError;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::new(s.to_string())
+            }
+        }
         impl std::ops::Deref for $name {
             type Target = String;
             fn deref(&self) -> &String {


### PR DESCRIPTION
Allows for easier deserialization of configuration.

Fixes: #202
Related: https://github.com/ramosbugs/oauth2-rs/pull/312