### PR TITLE
feat: Parse capitalized boolean strings

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -167,7 +167,7 @@ pub(crate) mod serde_string_bool {
             where
                 E: de::Error,
             {
-                v.parse().map_err(E::custom)
+                v.to_lowercase().parse().map_err(E::custom)
             }
         }
         deserializer.deserialize_any(BooleanLikeVisitor)


### PR DESCRIPTION
While integrating `openidconnect-rs`, I encountered responses where boolean fields are returned as **strings** (which is already handled by a feature flag), but they were additionally **capitalized** (`"True"` / `"False"`).

This caused deserialization to fail, even though the meaning of the values is obvious.

This is my first PR to an open-source project, so apologies if I’m missing any details or conventions.

If you have any suggestions regarding the implementation, scope, or preferred approach (e.g. feature-gating), I’ll be happy to adjust the PR accordingly.