### PR TITLE
Fix issuer URL comparison to handle trailing slashes

### DIFF
--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -380,7 +380,7 @@ where
         )
         .map_err(DiscoveryError::Parse)?;
 
-        if provider_metadata.issuer() != issuer_url {
+        if provider_metadata.issuer().url() != issuer_url.url() {
             Err(DiscoveryError::Validation(format!(
                 "unexpected issuer URI `{}` (expected `{}`)",
                 provider_metadata.issuer().as_str(),

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -319,7 +319,7 @@ where
             let unverified_claims = jwt.unverified_payload_ref();
             if self.iss_required {
                 if let Some(issuer) = unverified_claims.issuer() {
-                    if *issuer != self.issuer {
+                    if issuer.url() != self.issuer.url() {
                         return Err(ClaimsVerificationError::InvalidIssuer(format!(
                             "expected `{}` (found `{}`)",
                             *self.issuer, **issuer


### PR DESCRIPTION
Hi and thanks for a great crate! I have a small fix for handling trailing slashed in issuer_urls. This would solve #226 .

### Problem
The issuer URL validation was comparing wrapper types directly, which performs string-based comparison. This causes validation failures when comparing semantically equivalent URLs that differ only in trailing slashes (e.g., `example.com` vs `example.com/`).

### Solution
Changed the comparison to use `.url()` on both sides, which performs semantic URL comparison instead of lexical string comparison. This properly normalizes URLs before comparing them, treating `example.com` and `example.com/` as equivalent.