### PR TITLE
Fix reqwest-only tests to compile without the reqwest feature

### DIFF
--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -552,6 +552,7 @@ mod tests {
     }
     impl AdditionalClaims for TestClaims {}
 
+    #[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
     #[test]
     fn test_additional_claims() {
         let claims =
@@ -593,6 +594,7 @@ mod tests {
     struct AllOtherClaims(HashMap<String, serde_json::Value>);
     impl AdditionalClaims for AllOtherClaims {}
 
+    #[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
     #[test]
     fn test_catch_all_additional_claims() {
         let claims =

--- a/src/verification/tests.rs
+++ b/src/verification/tests.rs
@@ -1182,6 +1182,7 @@ fn test_new_id_token() {
     assert_eq!(claims, unverified);
 }
 
+#[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
 #[test]
 fn test_user_info_verified_claims() {
     let rsa_key =


### PR DESCRIPTION
This change guards the tests that reference `crate::reqwest::Error` behind the same feature gates that expose the reqwest backend.

Previously, these tests compiled unconditionally, which caused build failures when the crate was built without the reqwest feature enabled. The fix keeps the reqwest-specific test coverage active when reqwest is available, while allowing the library to build cleanly in non-reqwest configurations.

This is a small compile-time fix and does not change runtime behavior.

Before:

```bash
> cargo test --no-default-features --color always
   Compiling openidconnect v4.0.1 (~/openidconnect-rs)
error[E0433]: cannot find `reqwest` in `crate`
   --> src/user_info.rs:559:79
    |
559 |             UserInfoClaims::<TestClaims, CoreGenderClaim>::from_json::<crate::reqwest::Error>(
    |                                                                               ^^^^^^^ could not find `reqwest` in the crate root
    |
note: found an item that was configured out
   --> src/lib.rs:693:17
    |
692 | #[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
    |          --------------------------------------------------- the item is gated here
693 | pub use oauth2::reqwest;
    |                 ^^^^^^^

error[E0433]: cannot find `reqwest` in `crate`
   --> src/user_info.rs:581:75
    |
581 |         UserInfoClaims::<TestClaims, CoreGenderClaim>::from_json::<crate::reqwest::Error>(
    |                                                                           ^^^^^^^ could not find `reqwest` in the crate root
    |
note: found an item that was configured out
   --> src/lib.rs:693:17
    |
692 | #[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
    |          --------------------------------------------------- the item is gated here
693 | pub use oauth2::reqwest;
    |                 ^^^^^^^

error[E0433]: cannot find `reqwest` in `crate`
   --> src/user_info.rs:601:83
    |
601 |             UserInfoClaims::<AllOtherClaims, CoreGenderClaim>::from_json::<crate::reqwest::Error>(
    |                                                                                   ^^^^^^^ could not find `reqwest` in the crate root
    |
note: found an item that was configured out
   --> src/lib.rs:693:17
    |

692 | #[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
    |          --------------------------------------------------- the item is gated here
693 | pub use oauth2::reqwest;
    |                 ^^^^^^^

error[E0433]: cannot find `reqwest` in `crate`
    --> src/verification/tests.rs:1209:48
     |
1209 |         CoreUserInfoClaims::from_json::<crate::reqwest::Error>(json_claims.as_bytes(), Some(&sub))
     |                                                ^^^^^^^ could not find `reqwest` in the crate root
     |
note: found an item that was configured out
    --> src/lib.rs:693:17
     |
 692 | #[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
     |          --------------------------------------------------- the item is gated here
 693 | pub use oauth2::reqwest;
     |                 ^^^^^^^

error[E0433]: cannot find `reqwest` in `crate`
    --> src/verification/tests.rs:1219:50
     |
1219 |     match CoreUserInfoClaims::from_json::<crate::reqwest::Error>(
     |                                                  ^^^^^^^ could not find `reqwest` in the crate root
     |
note: found an item that was configured out
    --> src/lib.rs:693:17
     |
 692 | #[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
     |          --------------------------------------------------- the item is gated here
 693 | pub use oauth2::reqwest;
     |                 ^^^^^^^

...
error: could not compile `openidconnect` (lib test) due to 5 previous errors; 3 warnings emitted

~/openidconnect-rs tests !2                                                                                                                        6s
> 
```

AFTER:

```bash
running 9 tests
test src/lib.rs - (line 87) ... ignored
test src/lib.rs - (line 95) ... ignored
test src/lib.rs - (line 134) - compile ... ok
test src/lib.rs - (line 505) - compile ... ok
test src/lib.rs - (line 372) - compile ... ok
test src/lib.rs - (line 280) - compile ... ok
test src/lib.rs - (line 413) - compile ... ok
test src/jwt/mod.rs - jwt::NormalizedJsonWebTokenType (line 61) ... ok
test src/client.rs - client::Client (line 33) ... ok

test result: ok. 7 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 1.02s


~/openidconnect-rs tests !2                                                                                                                        8s
> 
```