### PR TITLE
bump crypto dependencies to newly released versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ required-features = ["reqwest-blocking"]
 name = "okta_device_grant"
 required-features = ["reqwest-blocking"]
 
+[patch.crates-io]
+# https://github.com/ramosbugs/oauth2-rs/pull/352
+oauth2 = { git = "https://github.com/baloo/oauth2-rs.git", branch = "baloo/push-utywpqtppwup" }
+
 [dependencies]
 base64 = "0.22"
 # Disable 'time' dependency since it triggers RUSTSEC-2020-0071 and we don't need it.
@@ -52,13 +56,13 @@ thiserror = "1.0"
 http = "1.0"
 itertools = "0.14"
 log = "0.4"
-oauth2 = { version = "5.0.0", default-features = false }
-rand = "0.8.5"
-hmac = "0.12.1"
-rsa = "0.9.2"
-sha2 = { version = "0.10.6", features = ["oid"] } # Object ID needed for pkcs1v15 padding
-p256 = "0.13.2"
-p384 = "0.13.0"
+oauth2 = { version = "5.1.0", default-features = false }
+rand = { version = "0.10", features = ["chacha"] }
+hmac = "0.13"
+rsa = "0.10.0-rc.18"
+sha2 = { version = "0.11", features = ["oid"] } # Object ID needed for pkcs1v15 padding
+p256 = "0.14"
+p384 = "0.14"
 dyn-clone = "1.0.10"
 serde = "1.0"
 serde_json = "1.0"
@@ -68,7 +72,7 @@ serde_with = "3"
 serde-value = "0.7"
 url = { version = "2.4", features = ["serde"] }
 subtle = "2.4"
-ed25519-dalek = { version = "2.0.0", features = ["pem"] }
+ed25519-dalek = { version = "3", features = ["pem"] }
 
 [dev-dependencies]
 color-backtrace = { version = "0.5" }

--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -81,9 +81,11 @@ pub fn verify_rsa_signature(
     // according to https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.1.1
     // `n` is always unsigned (hence has sign plus)
 
-    let n_bigint = rsa::BigUint::from_bytes_be(n.deref());
-    let e_bigint = rsa::BigUint::from_bytes_be(e.deref());
-    let public_key = rsa::RsaPublicKey::new(n_bigint, e_bigint)
+    let n = rsa::BoxedUint::from_be_slice_vartime(&n);
+    // the n slice may contain leading zeroes, strip those zeroes.
+    let n = rsa::BoxedUint::from_be_slice_vartime(&n.to_be_bytes_trimmed_vartime());
+    let e = rsa::BoxedUint::from_be_slice_vartime(&e);
+    let public_key = rsa::RsaPublicKey::new(n, e)
         .map_err(|e| SignatureVerificationError::InvalidKey(e.to_string()))?;
 
     public_key

--- a/src/core/jwk/mod.rs
+++ b/src/core/jwk/mod.rs
@@ -8,6 +8,8 @@ use crate::{
 
 use ed25519_dalek::pkcs8::DecodePrivateKey;
 use ed25519_dalek::Signer;
+use hmac::KeyInit;
+use rand::CryptoRng;
 use rsa::pkcs1::DecodeRsaPrivateKey;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -229,7 +231,7 @@ impl JsonWebKey for CoreJsonWebKey {
                 };
                 crypto::verify_rsa_signature(
                     self,
-                    rsa::Pss::new::<sha2::Sha256>(),
+                    rsa::Pss::<sha2::Sha256>::new(),
                     message,
                     signature,
                 )
@@ -242,7 +244,7 @@ impl JsonWebKey for CoreJsonWebKey {
                 };
                 crypto::verify_rsa_signature(
                     self,
-                    rsa::Pss::new::<sha2::Sha384>(),
+                    rsa::Pss::<sha2::Sha384>::new(),
                     message,
                     signature,
                 )
@@ -255,7 +257,7 @@ impl JsonWebKey for CoreJsonWebKey {
                 };
                 crypto::verify_rsa_signature(
                     self,
-                    rsa::Pss::new::<sha2::Sha512>(),
+                    rsa::Pss::<sha2::Sha512>::new(),
                     message,
                     signature,
                 )
@@ -272,7 +274,7 @@ impl JsonWebKey for CoreJsonWebKey {
                     SignatureVerificationError::Other(format!("Could not create key: {}", e))
                 })?;
                 mac.update(message);
-                mac.verify(signature.into())
+                mac.verify_slice(signature)
                     .map_err(|_| SignatureVerificationError::CryptoError("bad HMAC".to_string()))
             }
             CoreJwsSigningAlgorithm::HmacSha384 => {
@@ -287,7 +289,7 @@ impl JsonWebKey for CoreJsonWebKey {
                     SignatureVerificationError::Other(format!("Could not create key: {}", e))
                 })?;
                 mac.update(message);
-                mac.verify(signature.into())
+                mac.verify_slice(signature)
                     .map_err(|_| SignatureVerificationError::CryptoError("bad HMAC".to_string()))
             }
             CoreJwsSigningAlgorithm::HmacSha512 => {
@@ -302,7 +304,7 @@ impl JsonWebKey for CoreJsonWebKey {
                     SignatureVerificationError::Other(format!("Could not create key: {}", e))
                 })?;
                 mac.update(message);
-                mac.verify(signature.into())
+                mac.verify_slice(signature)
                     .map_err(|_| SignatureVerificationError::CryptoError("bad HMAC".to_string()))
             }
             CoreJwsSigningAlgorithm::EcdsaP256Sha256 => {
@@ -538,9 +540,9 @@ impl PrivateSigningKey for CoreEdDsaPrivateSigningKey {
 
 /// Trait used to allow testing with an alternative RNG.
 /// Clone is necessary to get a mutable version of the RNG.
-pub(crate) trait RngClone: dyn_clone::DynClone + rand::RngCore + rand::CryptoRng {}
+pub(crate) trait RngClone: dyn_clone::DynClone + rand::Rng + rand::CryptoRng {}
 dyn_clone::clone_trait_object!(RngClone);
-impl<T> RngClone for T where T: rand::RngCore + rand::CryptoRng + Clone {}
+impl<T> RngClone for T where T: rand::Rng + rand::CryptoRng + Clone {}
 
 /// RSA private key.
 ///
@@ -548,18 +550,18 @@ impl<T> RngClone for T where T: rand::RngCore + rand::CryptoRng + Clone {}
 /// them.
 pub struct CoreRsaPrivateSigningKey {
     key_pair: rsa::RsaPrivateKey,
-    rng: Box<dyn RngClone + Send + Sync>,
+    rng: Option<Box<dyn RngClone + Send + Sync>>,
     kid: Option<JsonWebKeyId>,
 }
 impl CoreRsaPrivateSigningKey {
     /// Converts an RSA private key (in PEM format) to a JWK representing its public key.
     pub fn from_pem(pem: &str, kid: Option<JsonWebKeyId>) -> Result<Self, String> {
-        Self::from_pem_internal(pem, Box::new(rand::rngs::OsRng), kid)
+        Self::from_pem_internal(pem, None, kid)
     }
 
     pub(crate) fn from_pem_internal(
         pem: &str,
-        rng: Box<dyn RngClone + Send + Sync>,
+        rng: Option<Box<dyn RngClone + Send + Sync>>,
         kid: Option<JsonWebKeyId>,
     ) -> Result<Self, String> {
         let key_pair = rsa::RsaPrivateKey::from_pkcs1_pem(pem).map_err(|err| err.to_string())?;
@@ -574,6 +576,12 @@ impl PrivateSigningKey for CoreRsaPrivateSigningKey {
         signature_alg: &CoreJwsSigningAlgorithm,
         msg: &[u8],
     ) -> Result<Vec<u8>, SigningError> {
+        let mut rng: Box<dyn CryptoRng> = if let Some(rng) = &self.rng {
+            rng.clone()
+        } else {
+            Box::new(rand::rng())
+        };
+
         match *signature_alg {
             CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256 => {
                 let mut hasher = sha2::Sha256::new();
@@ -581,11 +589,7 @@ impl PrivateSigningKey for CoreRsaPrivateSigningKey {
                 let hash = hasher.finalize().to_vec();
 
                 self.key_pair
-                    .sign_with_rng(
-                        &mut dyn_clone::clone_box(&self.rng),
-                        rsa::Pkcs1v15Sign::new::<sha2::Sha256>(),
-                        &hash,
-                    )
+                    .sign_with_rng(&mut rng, rsa::Pkcs1v15Sign::new::<sha2::Sha256>(), &hash)
                     .map_err(|_| SigningError::CryptoError)
             }
             CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha384 => {
@@ -594,11 +598,7 @@ impl PrivateSigningKey for CoreRsaPrivateSigningKey {
                 let hash = hasher.finalize().to_vec();
 
                 self.key_pair
-                    .sign_with_rng(
-                        &mut dyn_clone::clone_box(&self.rng),
-                        rsa::Pkcs1v15Sign::new::<sha2::Sha384>(),
-                        &hash,
-                    )
+                    .sign_with_rng(&mut rng, rsa::Pkcs1v15Sign::new::<sha2::Sha384>(), &hash)
                     .map_err(|_| SigningError::CryptoError)
             }
             CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha512 => {
@@ -607,11 +607,7 @@ impl PrivateSigningKey for CoreRsaPrivateSigningKey {
                 let hash = hasher.finalize().to_vec();
 
                 self.key_pair
-                    .sign_with_rng(
-                        &mut dyn_clone::clone_box(&self.rng),
-                        rsa::Pkcs1v15Sign::new::<sha2::Sha512>(),
-                        &hash,
-                    )
+                    .sign_with_rng(&mut rng, rsa::Pkcs1v15Sign::new::<sha2::Sha512>(), &hash)
                     .map_err(|_| SigningError::CryptoError)
             }
             CoreJwsSigningAlgorithm::RsaSsaPssSha256 => {
@@ -621,8 +617,8 @@ impl PrivateSigningKey for CoreRsaPrivateSigningKey {
 
                 self.key_pair
                     .sign_with_rng(
-                        &mut dyn_clone::clone_box(&self.rng),
-                        rsa::Pss::new_with_salt::<sha2::Sha256>(hash.len()),
+                        &mut rng,
+                        rsa::Pss::<sha2::Sha256>::new_with_salt(hash.len()),
                         &hash,
                     )
                     .map_err(|_| SigningError::CryptoError)
@@ -634,8 +630,8 @@ impl PrivateSigningKey for CoreRsaPrivateSigningKey {
 
                 self.key_pair
                     .sign_with_rng(
-                        &mut dyn_clone::clone_box(&self.rng),
-                        rsa::Pss::new_with_salt::<sha2::Sha384>(hash.len()),
+                        &mut rng,
+                        rsa::Pss::<sha2::Sha384>::new_with_salt(hash.len()),
                         &hash,
                     )
                     .map_err(|_| SigningError::CryptoError)
@@ -647,8 +643,8 @@ impl PrivateSigningKey for CoreRsaPrivateSigningKey {
 
                 self.key_pair
                     .sign_with_rng(
-                        &mut dyn_clone::clone_box(&self.rng),
-                        rsa::Pss::new_with_salt::<sha2::Sha512>(hash.len()),
+                        &mut rng,
+                        rsa::Pss::<sha2::Sha512>::new_with_salt(hash.len()),
                         &hash,
                     )
                     .map_err(|_| SigningError::CryptoError)
@@ -672,8 +668,12 @@ impl PrivateSigningKey for CoreRsaPrivateSigningKey {
             kty: CoreJsonWebKeyType::RSA,
             use_: Some(CoreJsonWebKeyUse::Signature),
             kid: self.kid.clone(),
-            n: Some(Base64UrlEncodedBytes::new(public_key.n().to_bytes_be())),
-            e: Some(Base64UrlEncodedBytes::new(public_key.e().to_bytes_be())),
+            n: Some(Base64UrlEncodedBytes::new(
+                public_key.n().to_be_bytes_trimmed_vartime().to_vec(),
+            )),
+            e: Some(Base64UrlEncodedBytes::new(
+                public_key.e().to_be_bytes_trimmed_vartime().to_vec(),
+            )),
             k: None,
             crv: None,
             x: None,

--- a/src/core/jwk/tests.rs
+++ b/src/core/jwk/tests.rs
@@ -13,8 +13,8 @@ use crate::{JsonWebKey, JsonWebKeyId, JsonWebTokenAlgorithm, PrivateSigningKey, 
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use rand::rngs::mock::StepRng;
-use rand::{CryptoRng, RngCore};
+use core::convert::Infallible;
+use rand::{TryCryptoRng, TryRng};
 use rsa::rand_core;
 
 #[test]
@@ -731,21 +731,30 @@ fn expect_rsa_sig(
 }
 
 #[derive(Clone)]
-struct TestRng(StepRng);
+struct TestRng {
+    x: u64,
+    increment: u64,
+}
+impl TestRng {
+    /// Construct a generator yielding an arithmetic sequence
+    fn new(x: u64, increment: u64) -> Self {
+        Self { x, increment }
+    }
+}
 
-impl CryptoRng for TestRng {}
-impl RngCore for TestRng {
-    fn next_u32(&mut self) -> u32 {
-        self.0.next_u32()
+impl TryCryptoRng for TestRng {}
+impl TryRng for TestRng {
+    type Error = Infallible;
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        self.try_next_u64().map(|x| x as u32)
     }
-    fn next_u64(&mut self) -> u64 {
-        self.0.next_u64()
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let res = self.x;
+        self.x = self.x.wrapping_add(self.increment);
+        Ok(res)
     }
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.0.fill_bytes(dest)
-    }
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.0.try_fill_bytes(dest)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        rand_core::utils::fill_bytes_via_next_word(dest, || self.try_next_u64())
     }
 }
 
@@ -795,7 +804,7 @@ fn test_rsa_signing() {
     let private_key = CoreRsaPrivateSigningKey::from_pem_internal(
         TEST_RSA_KEY,
         // Constant salt used for PSS test vectors below.
-        Box::new(TestRng(StepRng::new(127, 0))),
+        Some(Box::new(TestRng::new(127, 0))),
         Some(JsonWebKeyId::new("test_key".to_string())),
     )
     .unwrap();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,7 +4,7 @@ use crate::{AccessToken, AuthorizationCode};
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::Engine;
 use oauth2::helpers::deserialize_space_delimited_vec;
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -349,8 +349,12 @@ new_secret_type![
         /// # Arguments
         ///
         /// * `num_bytes` - Number of random bytes to generate, prior to base64-encoding.
-        pub fn new_random_len(num_bytes: u32) -> Self {
-            let random_bytes: Vec<u8> = (0..num_bytes).map(|_| thread_rng().gen::<u8>()).collect();
+        pub fn new_random_len(num_bytes: usize) -> Self {
+            let random_bytes: Vec<u8> = {
+                let mut buf = vec![0; num_bytes];
+                rng().fill(&mut buf[..]);
+                buf
+            };
             Nonce::new(BASE64_URL_SAFE_NO_PAD.encode(random_bytes))
         }
     }


### PR DESCRIPTION
This bumps:
 - `rand` to `0.10`
 - `hmac` to `0.13`
 - `rsa` to `0.10.0-rc.18`
 - `sha2` to `0.11`
 - `p256` to `0.14`
 - `p384` to `0.14`
 - `ed25519-dalek` to `3`