### PR TITLE
feat(discovery): support workload identity providers

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     IdTokenVerifier, JsonWebKeySet, JweContentEncryptionAlgorithm, JweKeyManagementAlgorithm,
     JwsSigningAlgorithm, ProviderMetadata, ResponseMode, ResponseType, StandardErrorResponse,
     StandardTokenIntrospectionResponse, StandardTokenResponse, SubjectIdentifierType,
-    UserInfoClaims, UserInfoJsonWebToken, UserInfoVerifier,
+    UserInfoClaims, UserInfoJsonWebToken, UserInfoVerifier, WorkloadProviderMetadata,
 };
 
 use base64::alphabet::URL_SAFE;
@@ -164,6 +164,10 @@ pub type CoreProviderMetadata = ProviderMetadata<
     CoreResponseType,
     CoreSubjectIdentifierType,
 >;
+
+/// Workload provider metadata using the core JSON Web Key types.
+pub type CoreWorkloadProviderMetadata =
+    WorkloadProviderMetadata<EmptyAdditionalProviderMetadata, CoreJsonWebKey>;
 
 /// OpenID Connect Core user info claims.
 pub type CoreUserInfoClaims = UserInfoClaims<EmptyAdditionalClaims, CoreGenderClaim>;

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -22,9 +22,12 @@ use std::future::Future;
 #[cfg(test)]
 mod tests;
 
+mod workload;
+pub use workload::WorkloadProviderMetadata;
+
 const CONFIG_URL_SUFFIX: &str = ".well-known/openid-configuration";
 
-/// Trait for adding extra fields to [`ProviderMetadata`].
+/// Trait for adding extra fields to [`ProviderMetadata`] or [`WorkloadProviderMetadata`].
 pub trait AdditionalProviderMetadata: Clone + Debug + DeserializeOwned + Serialize {}
 
 // In order to support serde flatten, this must be an empty struct rather than an empty
@@ -286,14 +289,12 @@ where
             .map_err(DiscoveryError::UrlParse)?;
 
         http_client
-            .call(
-                Self::discovery_request(discovery_url.clone()).map_err(|err| {
-                    DiscoveryError::Other(format!("failed to prepare request: {err}"))
-                })?,
-            )
+            .call(discovery_request(discovery_url.clone()).map_err(|err| {
+                DiscoveryError::Other(format!("failed to prepare request: {err}"))
+            })?)
             .map_err(DiscoveryError::Request)
             .and_then(|http_response| {
-                Self::discovery_response(issuer_url, &discovery_url, http_response)
+                discovery_response(issuer_url, &discovery_url, http_response, Self::issuer)
             })
             .and_then(|provider_metadata| {
                 JsonWebKeySet::fetch(provider_metadata.jwks_uri(), http_client).map(|jwks| Self {
@@ -319,15 +320,13 @@ where
                 .map_err(DiscoveryError::UrlParse)?;
 
             let provider_metadata = http_client
-                .call(
-                    Self::discovery_request(discovery_url.clone()).map_err(|err| {
-                        DiscoveryError::Other(format!("failed to prepare request: {err}"))
-                    })?,
-                )
+                .call(discovery_request(discovery_url.clone()).map_err(|err| {
+                    DiscoveryError::Other(format!("failed to prepare request: {err}"))
+                })?)
                 .await
                 .map_err(DiscoveryError::Request)
                 .and_then(|http_response| {
-                    Self::discovery_response(&issuer_url, &discovery_url, http_response)
+                    discovery_response(&issuer_url, &discovery_url, http_response, Self::issuer)
                 })?;
 
             JsonWebKeySet::fetch_async(provider_metadata.jwks_uri(), http_client)
@@ -339,58 +338,6 @@ where
         })
     }
 
-    fn discovery_request(discovery_url: url::Url) -> Result<HttpRequest, http::Error> {
-        http::Request::builder()
-            .uri(discovery_url.to_string())
-            .method(Method::GET)
-            .header(ACCEPT, HeaderValue::from_static(MIME_TYPE_JSON))
-            .body(Vec::new())
-    }
-
-    fn discovery_response<RE>(
-        issuer_url: &IssuerUrl,
-        discovery_url: &url::Url,
-        discovery_response: HttpResponse,
-    ) -> Result<Self, DiscoveryError<RE>>
-    where
-        RE: std::error::Error + 'static,
-    {
-        if discovery_response.status() != StatusCode::OK {
-            return Err(DiscoveryError::Response(
-                discovery_response.status(),
-                discovery_response.body().to_owned(),
-                format!(
-                    "HTTP status code {} at {}",
-                    discovery_response.status(),
-                    discovery_url
-                ),
-            ));
-        }
-
-        check_content_type(discovery_response.headers(), MIME_TYPE_JSON).map_err(|err_msg| {
-            DiscoveryError::Response(
-                discovery_response.status(),
-                discovery_response.body().to_owned(),
-                err_msg,
-            )
-        })?;
-
-        let provider_metadata = serde_path_to_error::deserialize::<_, Self>(
-            &mut serde_json::Deserializer::from_slice(discovery_response.body()),
-        )
-        .map_err(DiscoveryError::Parse)?;
-
-        if provider_metadata.issuer() != issuer_url {
-            Err(DiscoveryError::Validation(format!(
-                "unexpected issuer URI `{}` (expected `{}`)",
-                provider_metadata.issuer().as_str(),
-                issuer_url.as_str()
-            )))
-        } else {
-            Ok(provider_metadata)
-        }
-    }
-
     /// Returns additional provider metadata fields.
     pub fn additional_metadata(&self) -> &A {
         &self.additional_metadata
@@ -398,6 +345,61 @@ where
     /// Returns mutable additional provider metadata fields.
     pub fn additional_metadata_mut(&mut self) -> &mut A {
         &mut self.additional_metadata
+    }
+}
+
+fn discovery_request(discovery_url: url::Url) -> Result<HttpRequest, http::Error> {
+    http::Request::builder()
+        .uri(discovery_url.to_string())
+        .method(Method::GET)
+        .header(ACCEPT, HeaderValue::from_static(MIME_TYPE_JSON))
+        .body(Vec::new())
+}
+
+fn discovery_response<RE, M>(
+    issuer_url: &IssuerUrl,
+    discovery_url: &url::Url,
+    discovery_response: HttpResponse,
+    metadata_issuer: fn(&M) -> &IssuerUrl,
+) -> Result<M, DiscoveryError<RE>>
+where
+    RE: std::error::Error + 'static,
+    M: DeserializeOwned,
+{
+    if discovery_response.status() != StatusCode::OK {
+        return Err(DiscoveryError::Response(
+            discovery_response.status(),
+            discovery_response.body().to_owned(),
+            format!(
+                "HTTP status code {} at {}",
+                discovery_response.status(),
+                discovery_url
+            ),
+        ));
+    }
+
+    check_content_type(discovery_response.headers(), MIME_TYPE_JSON).map_err(|err_msg| {
+        DiscoveryError::Response(
+            discovery_response.status(),
+            discovery_response.body().to_owned(),
+            err_msg,
+        )
+    })?;
+
+    let provider_metadata = serde_path_to_error::deserialize::<_, M>(
+        &mut serde_json::Deserializer::from_slice(discovery_response.body()),
+    )
+    .map_err(DiscoveryError::Parse)?;
+
+    let actual_issuer = metadata_issuer(&provider_metadata);
+    if actual_issuer != issuer_url {
+        Err(DiscoveryError::Validation(format!(
+            "unexpected issuer URI `{}` (expected `{}`)",
+            actual_issuer.as_str(),
+            issuer_url.as_str()
+        )))
+    } else {
+        Ok(provider_metadata)
     }
 }
 

--- a/src/discovery/workload.rs
+++ b/src/discovery/workload.rs
@@ -1,0 +1,179 @@
+use super::{discovery_request, discovery_response, AdditionalProviderMetadata, CONFIG_URL_SUFFIX};
+use crate::{
+    AsyncHttpClient, ClientId, ClientSecret, DiscoveryError, IdTokenVerifier, IssuerUrl,
+    JsonWebKey, JsonWebKeySet, JsonWebKeySetUrl, SyncHttpClient,
+};
+
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, VecSkipError};
+use std::future::Future;
+
+#[cfg(test)]
+mod tests;
+
+/// Discovery metadata for issuers that publish signed workload tokens without a browser login flow.
+///
+/// This type requires `issuer`, `jwks_uri`, and `id_token_signing_alg_values_supported`. It does not
+/// require authorization or token endpoints, response types, or subject types. Use
+/// [`ProviderMetadata`](crate::ProviderMetadata) for full OpenID Connect login flows.
+///
+/// Discovery validates the issuer and fetches its keys using the supplied HTTP client. Configure
+/// that client not to follow redirects, and only discover issuers trusted by the application;
+/// do not discover arbitrary URLs taken from unverified token claims.
+///
+/// The returned verifier uses the existing ID token validation rules. Workload tokens must still
+/// contain the required ID token claims, including `iss`, `sub`, `aud`, `exp`, and `iat`.
+///
+/// ```no_run
+/// use openidconnect::core::{CoreIdToken, CoreWorkloadProviderMetadata};
+/// use openidconnect::{ClientId, IssuerUrl, Nonce};
+/// # #[cfg(feature = "reqwest")]
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let http_client = reqwest::Client::builder()
+///     .redirect(reqwest::redirect::Policy::none())
+///     .build()?;
+/// let metadata = CoreWorkloadProviderMetadata::discover_async(
+///     IssuerUrl::new("https://issuer.example".to_string())?,
+///     &http_client,
+/// ).await?;
+/// let verifier = metadata.id_token_verifier(ClientId::new("my-service".to_string()), None);
+/// let token: CoreIdToken = "received-token".parse()?;
+/// // Only skip nonce validation for tokens obtained outside a browser authorization flow.
+/// let claims = token.claims(&verifier, |_: Option<&Nonce>| Ok(()))?;
+/// # Ok(())
+/// # }
+/// ```
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct WorkloadProviderMetadata<A, K>
+where
+    A: AdditionalProviderMetadata,
+    K: JsonWebKey,
+{
+    issuer: IssuerUrl,
+    jwks_uri: JsonWebKeySetUrl,
+    #[serde(bound(deserialize = "K: JsonWebKey"))]
+    #[serde_as(as = "VecSkipError<_>")]
+    id_token_signing_alg_values_supported: Vec<K::SigningAlgorithm>,
+    #[serde(default = "JsonWebKeySet::default", skip)]
+    jwks: JsonWebKeySet<K>,
+    #[serde(bound(deserialize = "A: AdditionalProviderMetadata"), flatten)]
+    additional_metadata: A,
+}
+
+impl<A, K> WorkloadProviderMetadata<A, K>
+where
+    A: AdditionalProviderMetadata,
+    K: JsonWebKey,
+{
+    /// Instantiates workload provider metadata. Keys must be fetched or supplied with `set_jwks`
+    /// before verifying tokens.
+    pub fn new(
+        issuer: IssuerUrl,
+        jwks_uri: JsonWebKeySetUrl,
+        id_token_signing_alg_values_supported: Vec<K::SigningAlgorithm>,
+        additional_metadata: A,
+    ) -> Self {
+        Self {
+            issuer,
+            jwks_uri,
+            id_token_signing_alg_values_supported,
+            jwks: JsonWebKeySet::default(),
+            additional_metadata,
+        }
+    }
+
+    field_getters_setters![
+        pub self [self] ["workload provider metadata value"] {
+            set_issuer -> issuer[IssuerUrl],
+            set_jwks_uri -> jwks_uri[JsonWebKeySetUrl],
+            set_id_token_signing_alg_values_supported -> id_token_signing_alg_values_supported[Vec<K::SigningAlgorithm>],
+            set_jwks -> jwks[JsonWebKeySet<K>],
+        }
+    ];
+
+    /// Fetches workload discovery metadata and its JSON Web Key Set from a trusted issuer.
+    pub fn discover<C>(
+        issuer_url: &IssuerUrl,
+        http_client: &C,
+    ) -> Result<Self, DiscoveryError<<C as SyncHttpClient>::Error>>
+    where
+        C: SyncHttpClient,
+    {
+        let discovery_url = issuer_url
+            .join(CONFIG_URL_SUFFIX)
+            .map_err(DiscoveryError::UrlParse)?;
+        let response = http_client
+            .call(discovery_request(discovery_url.clone()).map_err(|err| {
+                DiscoveryError::Other(format!("failed to prepare request: {err}"))
+            })?)
+            .map_err(DiscoveryError::Request)?;
+        let metadata: Self =
+            discovery_response(issuer_url, &discovery_url, response, Self::issuer)?;
+        JsonWebKeySet::fetch(metadata.jwks_uri(), http_client).map(|jwks| metadata.set_jwks(jwks))
+    }
+
+    /// Asynchronously fetches workload discovery metadata and its JSON Web Key Set.
+    pub fn discover_async<'c, C>(
+        issuer_url: IssuerUrl,
+        http_client: &'c C,
+    ) -> impl Future<Output = Result<Self, DiscoveryError<<C as AsyncHttpClient<'c>>::Error>>> + 'c
+    where
+        Self: 'c,
+        C: AsyncHttpClient<'c>,
+    {
+        Box::pin(async move {
+            let discovery_url = issuer_url
+                .join(CONFIG_URL_SUFFIX)
+                .map_err(DiscoveryError::UrlParse)?;
+            let response = http_client
+                .call(discovery_request(discovery_url.clone()).map_err(|err| {
+                    DiscoveryError::Other(format!("failed to prepare request: {err}"))
+                })?)
+                .await
+                .map_err(DiscoveryError::Request)?;
+            let metadata: Self =
+                discovery_response(&issuer_url, &discovery_url, response, Self::issuer)?;
+            JsonWebKeySet::fetch_async(metadata.jwks_uri(), http_client)
+                .await
+                .map(|jwks| metadata.set_jwks(jwks))
+        })
+    }
+
+    /// Builds an ID token verifier using this issuer, its keys, and advertised signing algorithms.
+    ///
+    /// Supply the expected audience as `client_id`. A client secret is only needed for tokens
+    /// signed with a shared-secret algorithm. An empty or entirely unsupported algorithm list
+    /// permits no signing algorithms. Nonce and other claim checks use the existing
+    /// [`IdTokenVerifier`] defaults and can be configured on the returned verifier.
+    pub fn id_token_verifier<'a>(
+        &self,
+        client_id: ClientId,
+        client_secret: Option<ClientSecret>,
+    ) -> IdTokenVerifier<'a, K> {
+        let verifier = match client_secret {
+            Some(secret) => IdTokenVerifier::new_confidential_client(
+                client_id,
+                secret,
+                self.issuer.clone(),
+                self.jwks.clone(),
+            ),
+            None => IdTokenVerifier::new_public_client(
+                client_id,
+                self.issuer.clone(),
+                self.jwks.clone(),
+            ),
+        };
+        verifier.set_allowed_algs(self.id_token_signing_alg_values_supported.clone())
+    }
+
+    /// Returns additional provider metadata fields.
+    pub fn additional_metadata(&self) -> &A {
+        &self.additional_metadata
+    }
+
+    /// Returns mutable additional provider metadata fields.
+    pub fn additional_metadata_mut(&mut self) -> &mut A {
+        &mut self.additional_metadata
+    }
+}

--- a/src/discovery/workload/tests.rs
+++ b/src/discovery/workload/tests.rs
@@ -1,0 +1,441 @@
+use crate::core::{
+    CoreHmacKey, CoreIdToken, CoreIdTokenClaims, CoreJsonWebKey, CoreJsonWebKeySet,
+    CoreJwsSigningAlgorithm, CoreProviderMetadata, CoreRsaPrivateSigningKey,
+    CoreWorkloadProviderMetadata,
+};
+use crate::http_utils::{MIME_TYPE_JSON, MIME_TYPE_JWKS};
+use crate::jwt::tests::{TEST_RSA_PRIV_KEY, TEST_RSA_PUB_KEY};
+use crate::{
+    Audience, ClaimsVerificationError, ClientId, ClientSecret, DiscoveryError,
+    EmptyAdditionalProviderMetadata, HttpRequest, HttpResponse, IssuerUrl, JsonWebKeySetUrl, Nonce,
+    StandardClaims, SubjectIdentifier,
+};
+use chrono::{TimeZone, Utc};
+use http::header::{ACCEPT, CONTENT_TYPE};
+use serde_json::json;
+use std::cell::Cell;
+use std::future::Future;
+use std::sync::Arc;
+use std::task::{Context, Poll, Wake, Waker};
+
+const ISSUER: &str = "https://issuer.example/workload";
+const JWKS_URL: &str = "https://keys.example/jwks";
+const NOW: i64 = 1_700_000_000;
+
+fn metadata_json() -> serde_json::Value {
+    json!({
+        "issuer": ISSUER,
+        "jwks_uri": JWKS_URL,
+        "id_token_signing_alg_values_supported": ["RS256"]
+    })
+}
+
+fn metadata_with_keys() -> CoreWorkloadProviderMetadata {
+    serde_json::from_value::<CoreWorkloadProviderMetadata>(metadata_json())
+        .unwrap()
+        .set_jwks(CoreJsonWebKeySet::new(vec![serde_json::from_str::<
+            CoreJsonWebKey,
+        >(TEST_RSA_PUB_KEY)
+        .unwrap()]))
+}
+
+fn response(request: HttpRequest, document: &str) -> HttpResponse {
+    assert_eq!(request.method(), http::Method::GET);
+    assert!(request.body().is_empty());
+    let (content_type, body) = if request.uri() == JWKS_URL {
+        let accepts_jwks = request.headers()[ACCEPT]
+            .to_str()
+            .unwrap()
+            .split(',')
+            .any(|value| value.trim() == MIME_TYPE_JWKS);
+        if !accepts_jwks {
+            return http::Response::builder()
+                .status(406)
+                .body(Vec::new())
+                .unwrap();
+        }
+        (MIME_TYPE_JWKS, format!("{{\"keys\":[{TEST_RSA_PUB_KEY}]}}"))
+    } else {
+        assert_eq!(
+            request.uri(),
+            "https://issuer.example/workload/.well-known/openid-configuration"
+        );
+        assert_eq!(request.headers()[ACCEPT], MIME_TYPE_JSON);
+        (MIME_TYPE_JSON, document.to_string())
+    };
+    http::Response::builder()
+        .status(200)
+        .header(CONTENT_TYPE, content_type)
+        .body(body.into_bytes())
+        .unwrap()
+}
+
+fn poll_ready<T>(future: impl Future<Output = T>) -> T {
+    struct NoopWake;
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+    let waker = Waker::from(Arc::new(NoopWake));
+    match Box::pin(future)
+        .as_mut()
+        .poll(&mut Context::from_waker(&waker))
+    {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("mock HTTP responses should be immediately ready"),
+    }
+}
+
+#[test]
+fn test_workload_discovery_sync_and_async() {
+    let document = metadata_json().to_string();
+    let calls = Cell::new(0);
+    let client = |request| {
+        calls.set(calls.get() + 1);
+        Ok::<_, std::io::Error>(response(request, &document))
+    };
+    let issuer = IssuerUrl::new(ISSUER.to_string()).unwrap();
+    let metadata = CoreWorkloadProviderMetadata::discover(&issuer, &client).unwrap();
+    assert_eq!(calls.get(), 2);
+    assert_eq!(metadata.issuer(), &issuer);
+    assert_eq!(metadata.jwks_uri().as_str(), JWKS_URL);
+    assert_eq!(metadata.jwks(), metadata_with_keys().jwks());
+
+    let async_client = |request| std::future::ready(client(request));
+    let async_metadata = poll_ready(CoreWorkloadProviderMetadata::discover_async(
+        issuer,
+        &async_client,
+    ))
+    .unwrap();
+    assert_eq!(calls.get(), 4);
+    assert_eq!(metadata, async_metadata);
+    assert_eq!(serde_json::to_value(&metadata).unwrap(), metadata_json());
+}
+
+#[test]
+fn test_workload_metadata_required_fields_and_duplicates() {
+    for field in [
+        "issuer",
+        "jwks_uri",
+        "id_token_signing_alg_values_supported",
+    ] {
+        let mut document = metadata_json();
+        document.as_object_mut().unwrap().remove(field);
+        assert!(serde_json::from_value::<CoreWorkloadProviderMetadata>(document).is_err());
+        let mut document = metadata_json();
+        document[field] = serde_json::Value::Null;
+        assert!(serde_json::from_value::<CoreWorkloadProviderMetadata>(document).is_err());
+        let mut document = metadata_json().to_string();
+        document.pop();
+        document.push_str(&format!(",\"{field}\":{}}}", metadata_json()[field]));
+        assert!(serde_json::from_str::<CoreWorkloadProviderMetadata>(&document).is_err());
+    }
+    for field in ["issuer", "jwks_uri"] {
+        let mut document = metadata_json();
+        document[field] = json!("not a URL");
+        assert!(serde_json::from_value::<CoreWorkloadProviderMetadata>(document).is_err());
+    }
+}
+
+#[test]
+fn test_workload_metadata_extensions_and_unknown_algorithms() {
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+    struct ExtraMetadata {
+        claims_supported: Vec<String>,
+    }
+    impl crate::AdditionalProviderMetadata for ExtraMetadata {}
+    let mut document = metadata_json();
+    document["id_token_signing_alg_values_supported"] = json!(["future-alg", "RS256"]);
+    document["claims_supported"] = json!(["sub"]);
+    document["jwks"] =
+        json!({"keys": [serde_json::from_str::<serde_json::Value>(TEST_RSA_PUB_KEY).unwrap()]});
+    let mut metadata: crate::WorkloadProviderMetadata<ExtraMetadata, CoreJsonWebKey> =
+        serde_json::from_value(document).unwrap();
+    assert_eq!(
+        metadata.id_token_signing_alg_values_supported(),
+        &vec![CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256]
+    );
+    assert!(
+        metadata.jwks().keys().is_empty(),
+        "embedded keys must not be trusted"
+    );
+    assert_eq!(metadata.additional_metadata().claims_supported, vec!["sub"]);
+    metadata
+        .additional_metadata_mut()
+        .claims_supported
+        .push("aud".to_string());
+    assert_eq!(
+        serde_json::to_value(metadata).unwrap()["claims_supported"],
+        json!(["sub", "aud"])
+    );
+}
+
+#[test]
+fn test_workload_discovery_rejects_issuer_mismatch_before_fetching_keys() {
+    let mut document = metadata_json();
+    document["issuer"] = json!("https://untrusted.example");
+    let document = document.to_string();
+    let calls = Cell::new(0);
+    let client = |request: HttpRequest| {
+        calls.set(calls.get() + 1);
+        assert_ne!(request.uri(), JWKS_URL);
+        Ok::<_, std::io::Error>(response(request, &document))
+    };
+    let issuer = IssuerUrl::new(ISSUER.to_string()).unwrap();
+    assert!(matches!(
+        CoreWorkloadProviderMetadata::discover(&issuer, &client),
+        Err(DiscoveryError::Validation(_))
+    ));
+    let async_client = |request| std::future::ready(client(request));
+    assert!(matches!(
+        poll_ready(CoreWorkloadProviderMetadata::discover_async(
+            issuer,
+            &async_client
+        )),
+        Err(DiscoveryError::Validation(_))
+    ));
+    assert_eq!(calls.get(), 2);
+}
+
+#[test]
+fn test_workload_discovery_propagates_http_and_parse_errors() {
+    let issuer = IssuerUrl::new(ISSUER.to_string()).unwrap();
+    for fail_jwks in [false, true] {
+        for (status, content_type, body) in [
+            (500, MIME_TYPE_JSON, "{}"),
+            (200, "text/html", "{}"),
+            (200, MIME_TYPE_JSON, "not JSON"),
+        ] {
+            let calls = Cell::new(0);
+            let client = |request: HttpRequest| {
+                calls.set(calls.get() + 1);
+                Ok::<_, std::io::Error>(if (request.uri() == JWKS_URL) == fail_jwks {
+                    http::Response::builder()
+                        .status(status)
+                        .header(CONTENT_TYPE, content_type)
+                        .body(body.as_bytes().to_vec())
+                        .unwrap()
+                } else {
+                    response(request, &metadata_json().to_string())
+                })
+            };
+            let result = CoreWorkloadProviderMetadata::discover(&issuer, &client);
+            if body == "not JSON" {
+                assert!(matches!(result, Err(DiscoveryError::Parse(_))));
+            } else {
+                assert!(matches!(result, Err(DiscoveryError::Response(_, _, _))));
+            }
+            assert_eq!(calls.get(), if fail_jwks { 2 } else { 1 });
+        }
+    }
+    let client = |_| {
+        Err::<HttpResponse, _>(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "blocked by client",
+        ))
+    };
+    assert!(matches!(
+        CoreWorkloadProviderMetadata::discover(&issuer, &client),
+        Err(DiscoveryError::Request(_))
+    ));
+    let async_client = |request| std::future::ready(client(request));
+    assert!(matches!(
+        poll_ready(CoreWorkloadProviderMetadata::discover_async(
+            issuer,
+            &async_client
+        )),
+        Err(DiscoveryError::Request(_))
+    ));
+}
+
+#[test]
+fn test_full_provider_discovery_remains_strict() {
+    let error = serde_json::from_value::<CoreProviderMetadata>(metadata_json()).unwrap_err();
+    assert!(error.to_string().contains("authorization_endpoint"));
+    let mut document = metadata_json();
+    document["authorization_endpoint"] = json!("https://issuer.example/authorize");
+    document["token_endpoint"] = json!("https://issuer.example/token");
+    document["response_types_supported"] = json!(["code"]);
+    document["subject_types_supported"] = json!(["public"]);
+    let client = |request| Ok::<_, std::io::Error>(response(request, &document.to_string()));
+    let issuer = IssuerUrl::new(ISSUER.to_string()).unwrap();
+    let metadata = CoreProviderMetadata::discover(&issuer, &client).unwrap();
+    assert_eq!(
+        metadata.authorization_endpoint().as_str(),
+        "https://issuer.example/authorize"
+    );
+    let async_client = |request| std::future::ready(client(request));
+    assert_eq!(
+        metadata,
+        poll_ready(CoreProviderMetadata::discover_async(issuer, &async_client)).unwrap()
+    );
+}
+
+fn token_claims(issuer: &str, audience: &str, expiry: i64) -> CoreIdTokenClaims {
+    CoreIdTokenClaims::new(
+        IssuerUrl::new(issuer.to_string()).unwrap(),
+        vec![Audience::new(audience.to_string())],
+        Utc.timestamp_opt(expiry, 0).unwrap(),
+        Utc.timestamp_opt(NOW - 60, 0).unwrap(),
+        StandardClaims::new(SubjectIdentifier::new("workload".to_string())),
+        Default::default(),
+    )
+}
+
+#[test]
+fn test_workload_verifier_preserves_claim_and_signature_checks() {
+    let metadata = metadata_with_keys();
+    let verifier = metadata
+        .id_token_verifier(ClientId::new("service".to_string()), None)
+        .set_time_fn(|| Utc.timestamp_opt(NOW, 0).unwrap());
+    let key = CoreRsaPrivateSigningKey::from_pem(TEST_RSA_PRIV_KEY, None).unwrap();
+    let token = CoreIdToken::new(
+        token_claims(ISSUER, "service", NOW + 60),
+        &key,
+        CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256,
+        None,
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        token
+            .claims(&verifier, |_: Option<&Nonce>| Ok(()))
+            .unwrap()
+            .subject()
+            .as_str(),
+        "workload"
+    );
+    assert!(matches!(
+        token.claims(&verifier, &Nonce::new("required-nonce".to_string())),
+        Err(ClaimsVerificationError::InvalidNonce(_))
+    ));
+    for (issuer, audience, expiry) in [
+        ("https://wrong.example", "service", NOW + 60),
+        (ISSUER, "other-service", NOW + 60),
+        (ISSUER, "service", NOW - 1),
+    ] {
+        let token = CoreIdToken::new(
+            token_claims(issuer, audience, expiry),
+            &key,
+            CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256,
+            None,
+            None,
+        )
+        .unwrap();
+        let error = token
+            .claims(&verifier, |_: Option<&Nonce>| Ok(()))
+            .unwrap_err();
+        match (issuer == ISSUER, audience == "service") {
+            (false, _) => assert!(matches!(error, ClaimsVerificationError::InvalidIssuer(_))),
+            (_, false) => assert!(matches!(error, ClaimsVerificationError::InvalidAudience(_))),
+            _ => assert!(matches!(error, ClaimsVerificationError::Expired(_))),
+        }
+    }
+    let mut altered = token.to_string();
+    let signature_start = altered.rfind('.').unwrap() + 1;
+    let replacement = if altered.as_bytes()[signature_start] == b'A' {
+        "B"
+    } else {
+        "A"
+    };
+    altered.replace_range(signature_start..signature_start + 1, replacement);
+    let altered: CoreIdToken = altered.parse().unwrap();
+    assert!(matches!(
+        altered.claims(&verifier, |_: Option<&Nonce>| Ok(())),
+        Err(ClaimsVerificationError::SignatureVerification(_))
+    ));
+    for algorithms in [vec![], vec![CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha512]] {
+        let verifier = metadata
+            .clone()
+            .set_id_token_signing_alg_values_supported(algorithms)
+            .id_token_verifier(ClientId::new("service".to_string()), None)
+            .set_time_fn(|| Utc.timestamp_opt(NOW, 0).unwrap());
+        assert!(matches!(
+            token.claims(&verifier, |_: Option<&Nonce>| Ok(())),
+            Err(ClaimsVerificationError::SignatureVerification(_))
+        ));
+    }
+}
+
+#[test]
+fn test_workload_verifier_preserves_client_secret() {
+    let metadata = CoreWorkloadProviderMetadata::new(
+        IssuerUrl::new(ISSUER.to_string()).unwrap(),
+        JsonWebKeySetUrl::new(JWKS_URL.to_string()).unwrap(),
+        vec![CoreJwsSigningAlgorithm::HmacSha256],
+        EmptyAdditionalProviderMetadata {},
+    );
+    let token = CoreIdToken::new(
+        token_claims(ISSUER, "service", NOW + 60),
+        &CoreHmacKey::new(b"test-client-secret"),
+        CoreJwsSigningAlgorithm::HmacSha256,
+        None,
+        None,
+    )
+    .unwrap();
+    for secret in [None, Some("wrong-secret"), Some("test-client-secret")] {
+        let verifier = metadata
+            .id_token_verifier(
+                ClientId::new("service".to_string()),
+                secret.map(|value| ClientSecret::new(value.to_string())),
+            )
+            .set_time_fn(|| Utc.timestamp_opt(NOW, 0).unwrap());
+        assert_eq!(
+            token.claims(&verifier, |_: Option<&Nonce>| Ok(())).is_ok(),
+            secret == Some("test-client-secret")
+        );
+    }
+}
+
+#[test]
+fn test_workload_verifier_supports_borrowed_audience_policy() {
+    let metadata = metadata_with_keys();
+    let extra_audience = String::from("trusted-service");
+    let mut claims = token_claims(ISSUER, "service", NOW + 60);
+    claims = claims.set_audiences(vec![
+        Audience::new("service".to_string()),
+        Audience::new(extra_audience.clone()),
+    ]);
+    let key = CoreRsaPrivateSigningKey::from_pem(TEST_RSA_PRIV_KEY, None).unwrap();
+    let token = CoreIdToken::new(
+        claims,
+        &key,
+        CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256,
+        None,
+        None,
+    )
+    .unwrap();
+    let verifier = metadata
+        .id_token_verifier(ClientId::new("service".to_string()), None)
+        .set_time_fn(|| Utc.timestamp_opt(NOW, 0).unwrap());
+    assert!(matches!(
+        token.claims(&verifier, |_: Option<&Nonce>| Ok(())),
+        Err(ClaimsVerificationError::InvalidAudience(_))
+    ));
+    let verifier = verifier.set_other_audience_verifier_fn(|aud| aud.as_str() == extra_audience);
+    assert!(token.claims(&verifier, |_: Option<&Nonce>| Ok(())).is_ok());
+}
+
+#[test]
+fn test_workload_unsupported_algorithms_do_not_enable_defaults() {
+    let mut document = metadata_json();
+    document["id_token_signing_alg_values_supported"] = json!(["future-alg"]);
+    let metadata: CoreWorkloadProviderMetadata = serde_json::from_value(document).unwrap();
+    assert!(metadata.id_token_signing_alg_values_supported().is_empty());
+    let metadata = metadata.set_jwks(metadata_with_keys().jwks().clone());
+    let verifier = metadata
+        .id_token_verifier(ClientId::new("service".to_string()), None)
+        .set_time_fn(|| Utc.timestamp_opt(NOW, 0).unwrap());
+    let key = CoreRsaPrivateSigningKey::from_pem(TEST_RSA_PRIV_KEY, None).unwrap();
+    let token = CoreIdToken::new(
+        token_claims(ISSUER, "service", NOW + 60),
+        &key,
+        CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256,
+        None,
+        None,
+    )
+    .unwrap();
+    assert!(matches!(
+        token.claims(&verifier, |_: Option<&Nonce>| Ok(())),
+        Err(ClaimsVerificationError::SignatureVerification(_))
+    ));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -702,6 +702,7 @@ pub use crate::claims::{
 pub use crate::client::Client;
 pub use crate::discovery::{
     AdditionalProviderMetadata, DiscoveryError, EmptyAdditionalProviderMetadata, ProviderMetadata,
+    WorkloadProviderMetadata,
 };
 pub use crate::id_token::IdTokenFields;
 pub use crate::id_token::{IdToken, IdTokenClaims};

--- a/src/types/jwks.rs
+++ b/src/types/jwks.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use http::header::ACCEPT;
-use http::{HeaderValue, Method, StatusCode};
+use http::{Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, VecSkipError};
 
@@ -133,7 +133,7 @@ where
         http::Request::builder()
             .uri(url.to_string())
             .method(Method::GET)
-            .header(ACCEPT, HeaderValue::from_static(MIME_TYPE_JSON))
+            .header(ACCEPT, format!("{MIME_TYPE_JSON}, {MIME_TYPE_JWKS}"))
             .body(Vec::new())
     }
 

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -71,3 +71,75 @@ fn test_string_bool_parse() {
     test_case("\"false\"", false);
     assert!(serde_json::from_str::<Boolean>("\"maybe\"").is_err());
 }
+
+fn jwks_response(request: crate::HttpRequest, content_type: &str) -> crate::HttpResponse {
+    use http::header::{ACCEPT, CONTENT_TYPE};
+
+    assert_eq!(request.method(), http::Method::GET);
+    assert_eq!(request.uri(), "https://issuer.example/jwks");
+    assert!(request.body().is_empty());
+    let accepts_response = request.headers().get_all(ACCEPT).iter().any(|value| {
+        value
+            .to_str()
+            .unwrap()
+            .split(',')
+            .any(|media_type| media_type.trim() == content_type)
+    });
+    if !accepts_response {
+        return http::Response::builder()
+            .status(http::StatusCode::NOT_ACCEPTABLE)
+            .body(Vec::new())
+            .unwrap();
+    }
+    http::Response::builder()
+        .status(http::StatusCode::OK)
+        .header(CONTENT_TYPE, content_type)
+        .body(br#"{"keys":[]}"#.to_vec())
+        .unwrap()
+}
+
+#[test]
+fn test_jwks_fetch_media_types() {
+    use crate::core::CoreJsonWebKeySet;
+    use crate::http_utils::{MIME_TYPE_JSON, MIME_TYPE_JWKS};
+    use crate::JsonWebKeySetUrl;
+
+    let url = JsonWebKeySetUrl::new("https://issuer.example/jwks".to_string()).unwrap();
+    for content_type in [MIME_TYPE_JSON, MIME_TYPE_JWKS] {
+        let client = |request| Ok::<_, std::io::Error>(jwks_response(request, content_type));
+        let jwks = CoreJsonWebKeySet::fetch(&url, &client).unwrap();
+        assert!(jwks.keys().is_empty());
+    }
+}
+
+#[test]
+fn test_jwks_fetch_async_media_types() {
+    use crate::core::CoreJsonWebKeySet;
+    use crate::http_utils::{MIME_TYPE_JSON, MIME_TYPE_JWKS};
+    use crate::JsonWebKeySetUrl;
+    use std::future::Future;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    struct NoopWake;
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    let waker = Waker::from(Arc::new(NoopWake));
+    let mut context = Context::from_waker(&waker);
+    let url = JsonWebKeySetUrl::new("https://issuer.example/jwks".to_string()).unwrap();
+    for content_type in [MIME_TYPE_JSON, MIME_TYPE_JWKS] {
+        let client = |request| {
+            std::future::ready(Ok::<_, std::io::Error>(jwks_response(
+                request,
+                content_type,
+            )))
+        };
+        let mut future = Box::pin(CoreJsonWebKeySet::fetch_async(&url, &client));
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(result) => assert!(result.unwrap().keys().is_empty()),
+            Poll::Pending => panic!("mock HTTP response should be immediately ready"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Workload identity issuers such as Kubernetes and GitHub Actions can publish discovery documents for signed tokens without implementing browser authorization. The existing `ProviderMetadata` correctly requires the authorization endpoint for full OpenID Connect discovery, so it cannot represent these issuers. Separately, JWKS requests only advertise `application/json`, causing HTTP 406 from servers that require the registered `application/jwk-set+json` media type.

This PR addresses the two interoperability gaps in separate commits:

1. **`fix(jwks): accept the registered JWK set media type`** advertises both JSON media types in the shared JWKS request builder. The existing response parser already accepts both.
2. **`feat(discovery): add workload provider metadata`** adds `WorkloadProviderMetadata<A, K>` and `CoreWorkloadProviderMetadata`, with synchronous/asynchronous discovery and an `id_token_verifier` convenience method. The new type requires `issuer`, `jwks_uri`, and `id_token_signing_alg_values_supported`, but no browser login endpoints, response types, or subject types. It supports additional metadata through the existing extension trait.

Discovery request/response validation is shared with the existing provider type, including exact issuer validation before fetching keys. Verification reuses `IdTokenVerifier` with the advertised algorithms and optional client secret; signature, issuer, audience, expiration, and nonce policies are preserved. Unsupported algorithms retain the existing skip behavior, and an empty supported list permits no algorithms. Fetched keys are not serialized, and embedded `jwks` fields do not populate the verification key set.

## Compatibility

- Existing `ProviderMetadata`, `CoreProviderMetadata`, and `Client::from_provider_metadata` APIs and required fields are unchanged. The new type is opt-in and does not automatically relax parsing for existing callers.
- Workload tokens must satisfy the existing ID token claim requirements (`iss`, `sub`, `aud`, `exp`, and `iat`). This is not a general-purpose JWT verifier and does not add token exchange, authorization policy mapping, or a cache.
- Applications select trusted issuers, configure the HTTP client's outbound/redirect policy, and decide whether skipping nonce verification is appropriate for their non-browser flow. A documented async example demonstrates usage.
- No dependency additions or version changes. The first commit remains independently reviewable.

## Verification

- Both JWKS regression tests failed with HTTP 406 before the first commit and pass after it.
- `cargo test --offline -j 6 --tests --examples`: 80 unit tests passed.
- `cargo test --offline -j 6 --all-features`: 82 unit tests and 8 doctests passed.
- `cargo test --offline -j 6 --doc --no-default-features`: 8 doctests passed.
- `cargo clippy --offline -j 6 --all-targets --all-features`: completed with warnings in existing code; no warnings in the new workload implementation or tests.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

Tests cover synchronous/asynchronous discovery, strict JWKS content negotiation, metadata round trips and extensions, missing/null/duplicate fields, malformed URLs, unsupported algorithms, issuer mismatch before key fetching, HTTP/parse/client errors, unchanged full-provider discovery, real RSA signatures and negative claim/signature checks, nonce requirements, HMAC client secrets, and borrowed audience-policy callbacks.

Validated locally on macOS with Rust 1.98.0 using mock HTTP clients and existing test keys. Existing ignored external certification tests and live Kubernetes/GitHub Actions environments were not run; MSRV and other toolchains are left to CI.

## References

- [RFC 7517, Section 8.5.1](https://www.rfc-editor.org/rfc/rfc7517.html#section-8.5.1)
- [OpenID Connect Discovery provider metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata)
- [Workload discovery and JWKS interoperability report](https://github.com/rustfs/rustfs/issues/7330)
